### PR TITLE
Added default_dictionary to jar (resource)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,5 +54,14 @@
                 </executions>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/java</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>org/tinyradius/dictionary/default_dictionary</include>
+                </includes>
+            </resource>
+        </resources>
     </build>
 </project>


### PR DESCRIPTION
Fixes [StackOverflow](http://stackoverflow.com/questions/38334642/tinyradius-authenticate-method-results-in-nullpointerexception): 
```bash
java -cp ../tinyradius-1.0.2.jar:org/tinyradius/test:../../lib/commons-logging.jar org.tinyradius.test.TestClient hostName sharedSecret userName password
Exception in thread "main" java.lang.ExceptionInInitializerError
	at org.tinyradius.packet.RadiusPacket.<init>(RadiusPacket.java:1152)
	at org.tinyradius.packet.RadiusPacket.<init>(RadiusPacket.java:95)
	at org.tinyradius.packet.AccessRequest.<init>(AccessRequest.java:53)
	at org.tinyradius.test.TestClient.main(TestClient.java:40)
Caused by: java.lang.NullPointerException
	at java.io.Reader.<init>(Reader.java:78)
	at java.io.InputStreamReader.<init>(InputStreamReader.java:72)
	at org.tinyradius.dictionary.DictionaryParser.parseDictionary(DictionaryParser.java:58)
	at org.tinyradius.dictionary.DefaultDictionary.<clinit>(DefaultDictionary.java:48)
```
