### PR TITLE
AccountingRequest no arguments constructor sets the packet type as ACCOUNTING_REQUEST

### DIFF
--- a/src/main/java/org/tinyradius/packet/AccountingRequest.java
+++ b/src/main/java/org/tinyradius/packet/AccountingRequest.java
@@ -65,7 +65,7 @@ public class AccountingRequest extends RadiusPacket {
 	 * Radius client.
 	 */
 	public AccountingRequest() {
-		super();
+		super(ACCOUNTING_REQUEST);
 	}
 
 	/**


### PR DESCRIPTION
The empty constructor for AccountingRequest should still set the packet type as ACCOUNTING_REQUEST (since its an accounting request packet after all).

This just saves people from typing one additional line when using the empty constructor :)