### PR TITLE
aditional constructor to specify COA packet type

### DIFF
--- a/src/main/java/org/tinyradius/packet/CoaRequest.java
+++ b/src/main/java/org/tinyradius/packet/CoaRequest.java
@@ -11,7 +11,10 @@ import org.tinyradius.util.RadiusUtil;
 public class CoaRequest extends RadiusPacket {
 
 	public CoaRequest() {
-		super(COA_REQUEST, getNextPacketIdentifier()); 
+		this(COA_REQUEST);
+	}
+	public CoaRequest(final int type) {
+		super(type, getNextPacketIdentifier()); 
 	}
 	
 	/**


### PR DESCRIPTION
This constructor is necessary to create other COA packets like DISCONNECT_REQUEST