### PR TITLE
use unsigned values when converting to/from string in IntegerAttribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,14 @@
 			<artifactId>commons-logging</artifactId>
 			<version>1.1</version>
 		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/org/tinyradius/attribute/IntegerAttribute.java
+++ b/src/main/java/org/tinyradius/attribute/IntegerAttribute.java
@@ -55,8 +55,8 @@ public class IntegerAttribute extends RadiusAttribute {
 			if (name != null)
 				return name;
 		}
-
-		return Integer.toString(value);
+		// Radius uses only unsigned values....
+		return Long.toString(((long)value & 0xffffffffl));
 	}
 	
 	/**
@@ -87,7 +87,8 @@ public class IntegerAttribute extends RadiusAttribute {
 			}
 		}
 		
-		setAttributeValue(Integer.parseInt(value));
+		// Radius uses only unsigned integers for this the parser should consider as Long to parse high bit correctly...
+		setAttributeValue((int)Long.parseLong(value));
 	}
 	
 	/**

--- a/src/test/java/org/tinyradius/attribute/IntegerAttributeTest.java
+++ b/src/test/java/org/tinyradius/attribute/IntegerAttributeTest.java
@@ -1,0 +1,20 @@
+package org.tinyradius.attribute;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class IntegerAttributeTest {
+
+	@Test
+	public void test() {
+		final IntegerAttribute intAttr = new IntegerAttribute(27, 0);
+		final long bigValue = 0xffffffffl; // big value with highest bit set
+		System.err.println((int)bigValue);
+		System.err.println(bigValue);
+		final String bigValueSt = Long.toString(bigValue);
+		intAttr.setAttributeValue(bigValueSt);
+		assertEquals(bigValueSt, intAttr.getAttributeValue());
+	}
+
+}


### PR DESCRIPTION
Radius specs define Integers as Unsigned.

This patch changes the conversion from String to int using Long to permit big values.

Probably we should change other places to use long instead of ints, but this can create some incompatibilities.