### PR TITLE
Fixed PAP password encryption

### DIFF
--- a/src/main/java/org/tinyradius/packet/AccessRequest.java
+++ b/src/main/java/org/tinyradius/packet/AccessRequest.java
@@ -261,11 +261,11 @@ public class AccessRequest extends RadiusPacket {
 			md5.update(i == 0 ? getAuthenticator() : lastBlock);
 			byte bn[] = md5.digest();
 
-			System.arraycopy(encryptedPass, i, lastBlock, 0, 16);
-
 			// perform the XOR as specified by RFC 2865.
 			for (int j = 0; j < 16; j++)
 				encryptedPass[i + j] = (byte) (bn[j] ^ encryptedPass[i + j]);
+
+			System.arraycopy(encryptedPass, i, lastBlock, 0, 16);
 		}
 
 		return encryptedPass;


### PR DESCRIPTION
The PAP password encryption wasn't RFC2865 compliant.

The RFC says :
  b1 = MD5(S + RA)       c(1) = p1 xor b1
  b2 = MD5(S + c(1))     c(2) = p2 xor b2

What was implemented looked nothing like that.