### PR TITLE
POM improvements: Set source and target versions to Java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
 			<distribution>local</distribution>
 		</license>
 	</licenses>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>6</maven.compiler.source>
+		<maven.compiler.target>6</maven.compiler.target>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>commons-logging</groupId>


### PR DESCRIPTION
Set properties `maven.compiler.source` and `maven.compiler.target` to
"6" so that at least we control the value used and this project is
buildable with Maven 3.6.

Also set property `project.build.sourceEncoding` to "UTF-8" to get rid
of the warning.

I've picked Java 6 as a minimum, but I'd be happy to see it bumped to 8.