### PR TITLE
Build on OpenJDK 8 and OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: java
+jdk:
+  - openjdk8
+  - openjdk11
 services:
 - docker
 cache:


### PR DESCRIPTION
Tell Travis CI to build on OpenJDK 8 and OpenJDK 11 to ensure it works
with both.