### PR TITLE
Adding support starent attribute encoding and decoding

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 TinyRadius Change Log
 
+1.1.2:
+Support of 2 byte attribute tag length
+
 Plans for 1.0: Asynchronous Radius client (see TODO)
 
 0.9.9:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.tinyradius</groupId>
 	<artifactId>tinyradius</artifactId>
-	<version>1.1.1-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>TinyRadius Java Radius Library</name>
 	<description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.tinyradius</groupId>
 	<artifactId>tinyradius</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>TinyRadius Java Radius Library</name>
 	<description>

--- a/src/main/java/org/tinyradius/dictionary/AttributeType.java
+++ b/src/main/java/org/tinyradius/dictionary/AttributeType.java
@@ -1,5 +1,10 @@
 /**
  * $Id: AttributeType.java,v 1.3 2005/09/06 18:06:33 wuttke Exp $
+ * Copyright by teuto.net Netzdienste GmbH 2005. All rights reserved.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation. Commercial licenses also available.
+ * See the accompanying file LICENSE for details.
  * 
  * @author Matthias Wuttke
  * @version $Revision: 1.3 $
@@ -68,8 +73,9 @@ public class AttributeType {
 	 *            type code, 1-255
 	 */
 	public void setTypeCode(int code) {
-		if (code < 1 || code > 255)
-			throw new IllegalArgumentException("code out of bounds");
+                // Vendor specific attribute has values > 255 and < 1
+		/*if (code < 1 || code > 255)
+			throw new IllegalArgumentException("code out of bounds");*/
 		this.typeCode = code;
 	}
 

--- a/src/main/java/org/tinyradius/packet/RadiusPacket.java
+++ b/src/main/java/org/tinyradius/packet/RadiusPacket.java
@@ -215,8 +215,10 @@ public class RadiusPacket {
 	 *            packet type, 0-255
 	 */
 	public void setPacketType(int type) {
+                // Vendor specific attribute has values > 255 and < 1
+                /*
 		if (type < 1 || type > 255)
-			throw new IllegalArgumentException("packet type out of bounds");
+			throw new IllegalArgumentException("packet type out of bounds");*/
 		this.packetType = type;
 	}
 
@@ -325,8 +327,10 @@ public class RadiusPacket {
 	 *            attribute type to remove
 	 */
 	public void removeAttributes(int type) {
+                // Vendor specific attribute has values > 255 and < 1
+                /*
 		if (type < 1 || type > 255)
-			throw new IllegalArgumentException("attribute type out of bounds");
+			throw new IllegalArgumentException("attribute type out of bounds");*/
 
 		Iterator i = attributes.iterator();
 		while (i.hasNext()) {
@@ -393,8 +397,10 @@ public class RadiusPacket {
 	 * @return list of RadiusAttribute objects, does not return null
 	 */
 	public List getAttributes(int attributeType) {
+                // Vendor specific attribute has values > 255 and < 1
+                /*
 		if (attributeType < 1 || attributeType > 255)
-			throw new IllegalArgumentException("attribute type out of bounds");
+			throw new IllegalArgumentException("attribute type out of bounds");*/
 
 		LinkedList result = new LinkedList();
 		for (Iterator i = attributes.iterator(); i.hasNext();) {


### PR DESCRIPTION
Starent radius packet attribute length is 2 byte. While testing with decoding and encoding starent radius attribute, tinyradius was going infinite loop during decoding and failed to encode in case length more than 255. With this changes it now handles starent radius dictionary.
