### PR TITLE
Expose received packets list

### DIFF
--- a/src/main/java/org/tinyradius/util/RadiusServer.java
+++ b/src/main/java/org/tinyradius/util/RadiusServer.java
@@ -286,7 +286,16 @@ public abstract class RadiusServer {
 		this.duplicateInterval = duplicateInterval;
 	}
 
-	/**
+    /**
+     * Returns a list containing received packets
+     *
+     * @return list of received packets
+     */
+    public List getReceivedPackets() {
+        return receivedPackets;
+    }
+
+    /**
 	 * Returns the IP address the server listens on.
 	 * Returns null if listening on the wildcard address.
 	 * 

--- a/src/main/java/org/tinyradius/util/RadiusServer.java
+++ b/src/main/java/org/tinyradius/util/RadiusServer.java
@@ -286,16 +286,16 @@ public abstract class RadiusServer {
 		this.duplicateInterval = duplicateInterval;
 	}
 
-    /**
-     * Returns a list containing received packets
-     *
-     * @return list of received packets
-     */
-    public List getReceivedPackets() {
-        return receivedPackets;
-    }
+	/**
+	* Returns a list containing received packets
+	*
+	* @return list of received packets
+	*/
+	public List getReceivedPackets() {
+		return receivedPackets;
+	}
 
-    /**
+	/**
 	 * Returns the IP address the server listens on.
 	 * Returns null if listening on the wildcard address.
 	 * 


### PR DESCRIPTION
In some cases it should be allowed to edit/control received packets list. For example if you have a DB in getSharedSecret method and for some reason the connections fails you should be able to remove this package as it did not get processed so client can retry in hope our DB server will recover.