### PR TITLE
Fix Ipv6PrefixAttribute for variable prefix bit length.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
 	</licenses>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>6</maven.compiler.source>
-		<maven.compiler.target>6</maven.compiler.target>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -47,6 +47,12 @@
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.seancfoley</groupId>
+			<artifactId>ipaddress</artifactId>
+			<version>5.3.1</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/resources/org/tinyradius/dictionary/default_dictionary
+++ b/src/main/resources/org/tinyradius/dictionary/default_dictionary
@@ -81,7 +81,7 @@ ATTRIBUTE	Login-IPv6-Host		98	octets
 ATTRIBUTE	Framed-IPv6-Route	99	string
 ATTRIBUTE	Framed-IPv6-Pool	100	string
 ATTRIBUTE	Error-Cause		101	integer
-ATTRIBUTE	Delegated-Ipv6-Prefix	123	ipv6addr
+ATTRIBUTE	Delegated-IPv6-Prefix	123	ipv6prefix
 ATTRIBUTE	Framed-IPv6-Address	168	ipv6addr
 ATTRIBUTE	DNS-Server-IPv6-Address	169	ipv6addr
 ATTRIBUTE	Route-IPv6-Information	170	octets


### PR DESCRIPTION
Per RFCs, the "prefix" portion of IPv6 prefix attributes can be 0 -128 bits.  The existing code for Ipv6PrefixAttribute was limited to parsing 128 bit prefixes.  Modified class to allow prefixes that are smaller than 16 bytes and use SeanCFoley's IPAddress library to easily parse data.  Also updated default dictionary to properly define Delegated-IPv6-Prefix as type "ipv6prefix" (also set case of attribute name to standard convention). 