### PR TITLE
Fix duplicate packets check

### DIFF
--- a/src/main/java/org/tinyradius/util/RadiusServer.java
+++ b/src/main/java/org/tinyradius/util/RadiusServer.java
@@ -602,30 +602,30 @@ public abstract class RadiusServer {
 
 		byte[] authenticator = packet.getAuthenticator();
 
-        String uniqueKey = address.getAddress().getHostAddress() +
-                packet.getPacketIdentifier() +
-                Arrays.toString(packet.getAuthenticator());
+		String uniqueKey = address.getAddress().getHostAddress() +
+			packet.getPacketIdentifier() +
+                	Arrays.toString(packet.getAuthenticator());
 
-        synchronized (receivedPackets) {
-            if (lastClean == 0 || lastClean < now - getDuplicateInterval()) {
-                lastClean = now;
-                for (Iterator<Map.Entry<String, Long>> i = receivedPackets.entrySet().iterator(); i.hasNext(); ) {
-                    Long receiveTime = i.next().getValue();
-                    if (receiveTime < intervalStart) {
-                        // packet is older than duplicate interval
-                        i.remove();
-                    }
-                }
-            }
-        }
+		synchronized (receivedPackets) {
+		    if (lastClean == 0 || lastClean < now - getDuplicateInterval()) {
+			lastClean = now;
+			for (Iterator<Map.Entry<String, Long>> i = receivedPackets.entrySet().iterator(); i.hasNext(); ) {
+			    Long receiveTime = i.next().getValue();
+			    if (receiveTime < intervalStart) {
+				// packet is older than duplicate interval
+				i.remove();
+			    }
+			}
+		    }
+		}
 
-        Long receiveTime = receivedPackets.get(uniqueKey);
-        if (receiveTime == null) {
-            receivedPackets.put(uniqueKey, System.currentTimeMillis());
-            return false;
-        } else {
-            return !(receiveTime < intervalStart);
-        }
+		Long receiveTime = receivedPackets.get(uniqueKey);
+		if (receiveTime == null) {
+		    receivedPackets.put(uniqueKey, System.currentTimeMillis());
+		    return false;
+		} else {
+		    return !(receiveTime < intervalStart);
+		}
 	}
 
 	private InetAddress listenAddress = null;
@@ -634,8 +634,8 @@ public abstract class RadiusServer {
 	private DatagramSocket authSocket = null;
 	private DatagramSocket acctSocket = null;
 	private int socketTimeout = 3000;
-    private HashMap<String, Long> receivedPackets = new HashMap<>();
-    private long lastClean;
+	private HashMap<String, Long> receivedPackets = new HashMap<>();
+	private long lastClean;
 	private long duplicateInterval = 30000; // 30 s
 	protected transient boolean closing = false;
 	private static Log logger = LogFactory.getLog(RadiusServer.class);

--- a/src/main/java/org/tinyradius/util/RadiusServer.java
+++ b/src/main/java/org/tinyradius/util/RadiusServer.java
@@ -18,7 +18,6 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -607,7 +606,7 @@ public abstract class RadiusServer {
                 	Arrays.toString(packet.getAuthenticator());
 
 		synchronized (receivedPackets) {
-		    if (lastClean == 0 || lastClean < now - getDuplicateInterval()) {
+			if (lastClean == 0 || lastClean < now - getDuplicateInterval()) {
 			lastClean = now;
 			for (Iterator<Map.Entry<String, Long>> i = receivedPackets.entrySet().iterator(); i.hasNext(); ) {
 			    Long receiveTime = i.next().getValue();
@@ -616,15 +615,14 @@ public abstract class RadiusServer {
 				i.remove();
 			    }
 			}
-		    }
-		}
-
-		Long receiveTime = receivedPackets.get(uniqueKey);
-		if (receiveTime == null) {
-		    receivedPackets.put(uniqueKey, System.currentTimeMillis());
-		    return false;
-		} else {
-		    return !(receiveTime < intervalStart);
+			
+			Long receiveTime = receivedPackets.get(uniqueKey);
+			if (receiveTime == null) {
+			    receivedPackets.put(uniqueKey, System.currentTimeMillis());
+			    return false;
+			} else {
+			    return !(receiveTime < intervalStart);
+			}
 		}
 	}
 

--- a/src/main/java/org/tinyradius/util/RadiusServer.java
+++ b/src/main/java/org/tinyradius/util/RadiusServer.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -287,11 +289,11 @@ public abstract class RadiusServer {
 	}
 
 	/**
-	* Returns a list containing received packets
+	* Returns a map containing received packets
 	*
 	* @return list of received packets
 	*/
-	public List getReceivedPackets() {
+	public Map<String, Long> getReceivedPackets() {
 		return receivedPackets;
 	}
 
@@ -600,36 +602,30 @@ public abstract class RadiusServer {
 
 		byte[] authenticator = packet.getAuthenticator();
 
-		synchronized (receivedPackets) {
-			for (Iterator i = receivedPackets.iterator(); i.hasNext();) {
-				ReceivedPacket p = (ReceivedPacket) i.next();
-				if (p.receiveTime < intervalStart) {
-					// packet is older than duplicate interval
-					i.remove();
-				}
-				else {
-					if (p.address.equals(address) && p.packetIdentifier == packet.getPacketIdentifier()) {
-						if (authenticator != null && p.authenticator != null) {
-							// packet is duplicate if stored authenticator is equal
-							// to the packet authenticator
-							return Arrays.equals(p.authenticator, authenticator);
-						}
-						// should not happen, packet is duplicate
-						return true;
-					}
-				}
-			}
+        String uniqueKey = address.getAddress().getHostAddress() +
+                packet.getPacketIdentifier() +
+                Arrays.toString(packet.getAuthenticator());
 
-			// add packet to receive list
-			ReceivedPacket rp = new ReceivedPacket();
-			rp.address = address;
-			rp.packetIdentifier = packet.getPacketIdentifier();
-			rp.receiveTime = now;
-			rp.authenticator = authenticator;
-			receivedPackets.add(rp);
-		}
+        synchronized (receivedPackets) {
+            if (lastClean == 0 || lastClean < now - getDuplicateInterval()) {
+                lastClean = now;
+                for (Iterator<Map.Entry<String, Long>> i = receivedPackets.entrySet().iterator(); i.hasNext(); ) {
+                    Long receiveTime = i.next().getValue();
+                    if (receiveTime < intervalStart) {
+                        // packet is older than duplicate interval
+                        i.remove();
+                    }
+                }
+            }
+        }
 
-		return false;
+        Long receiveTime = receivedPackets.get(uniqueKey);
+        if (receiveTime == null) {
+            receivedPackets.put(uniqueKey, System.currentTimeMillis());
+            return false;
+        } else {
+            return !(receiveTime < intervalStart);
+        }
 	}
 
 	private InetAddress listenAddress = null;
@@ -638,37 +634,10 @@ public abstract class RadiusServer {
 	private DatagramSocket authSocket = null;
 	private DatagramSocket acctSocket = null;
 	private int socketTimeout = 3000;
-	private List receivedPackets = new LinkedList();
+    private HashMap<String, Long> receivedPackets = new HashMap<>();
+    private long lastClean;
 	private long duplicateInterval = 30000; // 30 s
 	protected transient boolean closing = false;
 	private static Log logger = LogFactory.getLog(RadiusServer.class);
-
-}
-
-/**
- * This internal class represents a packet that has been received by
- * the server.
- */
-class ReceivedPacket {
-
-	/**
-	 * The identifier of the packet.
-	 */
-	public int packetIdentifier;
-
-	/**
-	 * The time the packet was received.
-	 */
-	public long receiveTime;
-
-	/**
-	 * The address of the host who sent the packet.
-	 */
-	public InetSocketAddress address;
-
-	/**
-	 * Authenticator of the received packet.
-	 */
-	public byte[] authenticator;
 
 }

--- a/src/main/java/org/tinyradius/util/RadiusServer.java
+++ b/src/main/java/org/tinyradius/util/RadiusServer.java
@@ -601,27 +601,28 @@ public abstract class RadiusServer {
 
 		byte[] authenticator = packet.getAuthenticator();
 
-		String uniqueKey = address.getAddress().getHostAddress() +
-			packet.getPacketIdentifier() +
-                	Arrays.toString(packet.getAuthenticator());
+		String uniqueKey = address.getAddress().getHostAddress()+ 
+			packet.getPacketIdentifier() + 
+			Arrays.toString(packet.getAuthenticator());
 
 		synchronized (receivedPackets) {
 			if (lastClean == 0 || lastClean < now - getDuplicateInterval()) {
-			lastClean = now;
-			for (Iterator<Map.Entry<String, Long>> i = receivedPackets.entrySet().iterator(); i.hasNext(); ) {
-			    Long receiveTime = i.next().getValue();
-			    if (receiveTime < intervalStart) {
-				// packet is older than duplicate interval
-				i.remove();
-			    }
+				lastClean = now;
+				for (Iterator<Map.Entry<String, Long>> i = receivedPackets.entrySet().iterator(); i.hasNext(); ) {
+					Long receiveTime = i.next().getValue();
+					if (receiveTime < intervalStart) {
+						// packet is older than duplicate interval
+						i.remove();
+					}
+				}
 			}
-			
+
 			Long receiveTime = receivedPackets.get(uniqueKey);
 			if (receiveTime == null) {
-			    receivedPackets.put(uniqueKey, System.currentTimeMillis());
-			    return false;
+				receivedPackets.put(uniqueKey, System.currentTimeMillis());
+				return false;
 			} else {
-			    return !(receiveTime < intervalStart);
+				return !(receiveTime < intervalStart);
 			}
 		}
 	}


### PR DESCRIPTION
There is a bug on line [615](https://github.com/ctran/TinyRadius/blob/9b226fdb743b83bef025b20d75e4eea0c819aa25/src/main/java/org/tinyradius/util/RadiusServer.java#L615) where packet is check for duplicate. Even if the packet is marked as non duplicate after auth header check it still not added in list as received packet.
Also I have introduced a more faster method and structure for maintaining this information. With high load/throughput radius server a lot of time was wasted in constantly iterating over the list every time especially in sync block. 
With new structure, old record are deleted periodicity and we are not iterating over this list all the time.