### PR TITLE
Update RadiusClient.java

### DIFF
--- a/src/main/java/org/tinyradius/util/RadiusClient.java
+++ b/src/main/java/org/tinyradius/util/RadiusClient.java
@@ -370,7 +370,7 @@ public class RadiusClient {
 	 * @throws SocketException
 	 */
 	protected DatagramSocket getSocket() throws SocketException {
-		if (serverSocket == null) {
+		if (serverSocket == null || serverSocket.isClosed()) {
 			serverSocket = new DatagramSocket();
 			serverSocket.setSoTimeout(getSocketTimeout());
 		}


### PR DESCRIPTION
Fix closed socket. Socket is available via the getSocket method even if already closed. Retrieving a closed socket will produce exception after first communication.

Reacreate:
1 - Start server - org.tinyradius.test.TestServer
2 - Start client - org.tinyradius.test.TestClient - with args: ("127.0.0.1", "testing123", "mw", "test")

```
java.net.SocketException: Socket is closed

	at java.net.DatagramSocket.send(DatagramSocket.java:658)
	at org.tinyradius.util.RadiusClient.communicate(RadiusClient.java:316)
	at org.tinyradius.util.RadiusClient.account(RadiusClient.java:137)
	at org.tinyradius.test.TestClient.main(TestClient.java:60)

```