### PR TITLE
Upgraded commons-logging to make log4j optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
-			<version>1.1</version>
+			<version>1.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bumped version to commons-logging 1.2 where log4j is optional.
log4j 1 is EOL, has some CVEs and shouldn't be used anymore.