### PR TITLE
switched from commons-logging to logback-classic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<version>1.1</version>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.7</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/tinyradius/packet/AccessRequest.java
+++ b/src/main/java/org/tinyradius/packet/AccessRequest.java
@@ -14,8 +14,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tinyradius.attribute.RadiusAttribute;
 import org.tinyradius.attribute.StringAttribute;
 import org.tinyradius.util.RadiusException;
@@ -318,8 +318,8 @@ public class AccessRequest extends RadiusPacket {
 	private String decodePapPassword(byte[] encryptedPass, byte[] sharedSecret) throws RadiusException {
 		if (encryptedPass == null || encryptedPass.length < 16) {
 			// PAP passwords require at least 16 bytes
-			logger.warn("invalid Radius packet: User-Password attribute with malformed PAP password, length = "
-			        + (encryptedPass == null ? 0 : encryptedPass.length) + ", but length must be greater than 15");
+			logger.warn("invalid Radius packet: User-Password attribute with malformed PAP password, length = {}"
+					+ ", but length must be greater than 15", (encryptedPass == null ? 0 : encryptedPass.length));
 			throw new RadiusException("malformed User-Password attribute");
 		}
 
@@ -478,6 +478,6 @@ public class AccessRequest extends RadiusPacket {
 	/**
 	 * Logger for logging information about malformed packets
 	 */
-	private static Log logger = LogFactory.getLog(AccessRequest.class);
+	private static Logger logger = LoggerFactory.getLogger(AccessRequest.class);
 
 }

--- a/src/main/java/org/tinyradius/proxy/RadiusProxy.java
+++ b/src/main/java/org/tinyradius/proxy/RadiusProxy.java
@@ -17,8 +17,9 @@ import java.net.SocketException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tinyradius.attribute.RadiusAttribute;
 import org.tinyradius.packet.RadiusPacket;
 import org.tinyradius.util.RadiusEndpoint;
@@ -43,7 +44,7 @@ public abstract class RadiusProxy extends RadiusServer {
 				public void run() {
 					setName("Radius Proxy Listener");
 					try {
-						logger.info("starting RadiusProxyListener on port " + getProxyPort());
+						logger.info("starting RadiusProxyListener on port {}", getProxyPort());
 						listen(getProxySocket());
 					}
 					catch (Exception e) {
@@ -149,7 +150,7 @@ public abstract class RadiusProxy extends RadiusServer {
 		if (radiusServer != null) {
 			// proxy incoming packet to other radius server
 			RadiusProxyConnection proxyConnection = new RadiusProxyConnection(radiusServer, radiusClient, request, localAddress.getPort());
-			logger.info("proxy packet to " + proxyConnection);
+			logger.info("proxy packet to {}", proxyConnection);
 			proxyPacket(request, proxyConnection);
 			return null;
 		}
@@ -186,8 +187,8 @@ public abstract class RadiusProxy extends RadiusServer {
 		// retrieve client
 		RadiusEndpoint client = proxyConnection.getRadiusClient();
 		if (logger.isInfoEnabled()) {
-			logger.info("received proxy packet: " + packet);
-			logger.info("forward packet to " + client.getEndpointAddress().toString() + " with secret " + client.getSharedSecret());
+			logger.info("received proxy packet: {}", packet);
+			logger.info("forward packet to {} with secret {}", client.getEndpointAddress().toString(), client.getSharedSecret());
 		}
 
 		// remove only own Proxy-State (last attribute)
@@ -265,6 +266,6 @@ public abstract class RadiusProxy extends RadiusServer {
 
 	private int proxyPort = 1814;
 	private DatagramSocket proxySocket = null;
-	private static Log logger = LogFactory.getLog(RadiusProxy.class);
+	private static Logger logger = LoggerFactory.getLogger(RadiusProxy.class);
 
 }

--- a/src/main/java/org/tinyradius/util/RadiusClient.java
+++ b/src/main/java/org/tinyradius/util/RadiusClient.java
@@ -15,8 +15,8 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tinyradius.packet.AccessRequest;
 import org.tinyradius.packet.AccountingRequest;
 import org.tinyradius.packet.RadiusPacket;
@@ -111,11 +111,11 @@ public class RadiusClient {
 	 */
 	public synchronized RadiusPacket authenticate(AccessRequest request) throws IOException, RadiusException {
 		if (logger.isInfoEnabled())
-			logger.info("send Access-Request packet: " + request);
+			logger.info("send Access-Request packet: {}", request);
 
 		RadiusPacket response = communicate(request, getAuthPort());
 		if (logger.isInfoEnabled())
-			logger.info("received packet: " + response);
+			logger.info("received packet: {}", response);
 
 		return response;
 	}
@@ -135,11 +135,11 @@ public class RadiusClient {
 	 */
 	public synchronized RadiusPacket account(AccountingRequest request) throws IOException, RadiusException {
 		if (logger.isInfoEnabled())
-			logger.info("send Accounting-Request packet: " + request);
+			logger.info("send Accounting-Request packet: {}", request);
 
 		RadiusPacket response = communicate(request, getAcctPort());
 		if (logger.isInfoEnabled())
-			logger.info("received packet: " + response);
+			logger.info("received packet: {}", response);
 
 		return response;
 	}
@@ -330,7 +330,7 @@ public class RadiusClient {
 						throw ioex;
 					}
 					if (logger.isInfoEnabled())
-						logger.info("communication failure, retry " + i);
+						logger.info("communication failure, retry {}", i);
 					// TODO increase Acct-Delay-Time by getSocketTimeout()/1000
 					// this changes the packet authenticator and requires packetOut to be
 					// calculated again (call makeDatagramPacket)
@@ -419,6 +419,6 @@ public class RadiusClient {
 	private int retryCount = 3;
 	private int socketTimeout = 3000;
 	private String authProtocol = AccessRequest.AUTH_PAP;
-	private static Log logger = LogFactory.getLog(RadiusClient.class);
+	private static Logger logger = LoggerFactory.getLogger(RadiusClient.class);
 
 }

--- a/src/main/java/org/tinyradius/util/RadiusServer.java
+++ b/src/main/java/org/tinyradius/util/RadiusServer.java
@@ -22,8 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tinyradius.attribute.RadiusAttribute;
 import org.tinyradius.packet.AccessRequest;
 import org.tinyradius.packet.AccountingRequest;
@@ -138,13 +138,13 @@ public abstract class RadiusServer {
 				public void run() {
 					setName("Radius Auth Listener");
 					try {
-						logger.info("starting RadiusAuthListener on port " + getAuthPort());
+						logger.info("starting RadiusAuthListener on port {}", getAuthPort());
 						listenAuth();
 						logger.info("RadiusAuthListener is being terminated");
 					}
 					catch (Exception e) {
 						e.printStackTrace();
-						logger.fatal("auth thread stopped by exception", e);
+						logger.error("FATAL: auth thread stopped by exception", e);
 					}
 					finally {
 						authSocket.close();
@@ -159,13 +159,13 @@ public abstract class RadiusServer {
 				public void run() {
 					setName("Radius Acct Listener");
 					try {
-						logger.info("starting RadiusAcctListener on port " + getAcctPort());
+						logger.info("starting RadiusAcctListener on port {}", getAcctPort());
 						listenAcct();
 						logger.info("RadiusAcctListener is being terminated");
 					}
 					catch (Exception e) {
 						e.printStackTrace();
-						logger.fatal("acct thread stopped by exception", e);
+						logger.error("FATAL: acct thread stopped by exception", e);
 					}
 					finally {
 						acctSocket.close();
@@ -374,7 +374,7 @@ public abstract class RadiusServer {
 					logger.trace("about to call socket.receive()");
 					s.receive(packetIn);
 					if (logger.isDebugEnabled())
-						logger.debug("receive buffer size = " + s.getReceiveBufferSize());
+						logger.debug("receive buffer size = {}", s.getReceiveBufferSize());
 				}
 				catch (SocketException se) {
 					if (closing) {
@@ -429,14 +429,14 @@ public abstract class RadiusServer {
 			final String secret = getSharedSecret(remoteAddress, makeRadiusPacket(packetIn, "1234567890", RadiusPacket.RESERVED));
 			if (secret == null) {
 				if (logger.isInfoEnabled())
-					logger.info("ignoring packet from unknown client " + remoteAddress + " received on local address " + localAddress);
+					logger.info("ignoring packet from unknown client {} received on local address {}", remoteAddress,  localAddress);
 				return;
 			}
 
 			// parse packet
 			final RadiusPacket request = makeRadiusPacket(packetIn, secret, RadiusPacket.UNDEFINED);
 			if (logger.isInfoEnabled())
-				logger.info("received packet from " + remoteAddress + " on local address " + localAddress + ": " + request);
+				logger.info("received packet from {} on local address {}", remoteAddress, localAddress + ": " + request);
 
 			// handle packet
 			logger.trace("about to call RadiusServer.handlePacket()");
@@ -445,7 +445,7 @@ public abstract class RadiusServer {
 			// send response
 			if (response != null) {
 				if (logger.isInfoEnabled())
-					logger.info("send response: " + response);
+					logger.info("send response: {}", response);
 				final DatagramPacket packetOut = makeDatagramPacket(response, secret, remoteAddress.getAddress(), packetIn.getPort(), request);
 				s.send(packetOut);
 			}
@@ -487,14 +487,14 @@ public abstract class RadiusServer {
 				if (request instanceof AccessRequest)
 					response = accessRequestReceived((AccessRequest) request, remoteAddress);
 				else
-					logger.error("unknown Radius packet type: " + request.getPacketType());
+					logger.error("unknown Radius packet type: {}", request.getPacketType());
 			}
 			else if (localAddress.getPort() == getAcctPort()) {
 				// handle packets on acct port
 				if (request instanceof AccountingRequest)
 					response = accountingRequestReceived((AccountingRequest) request, remoteAddress);
 				else
-					logger.error("unknown Radius packet type: " + request.getPacketType());
+					logger.error("unknown Radius packet type: {}", request.getPacketType());
 			}
 			else {
 				// ignore packet on unknown port
@@ -637,6 +637,6 @@ public abstract class RadiusServer {
 	private long lastClean;
 	private long duplicateInterval = 30000; // 30 s
 	protected transient boolean closing = false;
-	private static Log logger = LogFactory.getLog(RadiusServer.class);
+	private static Logger logger = LoggerFactory.getLogger(RadiusServer.class);
 
 }


### PR DESCRIPTION
In the recent events of log4j vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) I checked this repo for exposure and found it is not vulnerable to this CVE as commons-logging 1.1 ships with log4j version 1.2.12. Unfortunately this version of log4j has [CVE-2021-4104](https://access.redhat.com/security/cve/CVE-2021-4104) and should be fixed in my opinion. 

I have done the migration to logback classic which is not vulnerable to either of listed CVEs. It is a modern and up to date logging framework and changes to the code base are minimal.