### PR TITLE
Java 8/Junit 5 Migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: 8
-        distribution: adopt
+        java-version: 11
+        distribution: temurin
     - name: Build with Maven
       run: mvn -V -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.tinyradius</groupId>
 	<artifactId>tinyradius</artifactId>
-	<version>1.1.1-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>TinyRadius Java Radius Library</name>
 	<description>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,22 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.1.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<showDeprecation>true</showDeprecation>
+					<compilerArgs>-Xlint:unchecked</compilerArgs>
+					<!-- Requires mvn 3.6 or later -->
+					<release>8</release>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.8.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -87,6 +87,12 @@
 					<!-- Release directive requires mvn 3.6 and Java 9 or later -->
 					<release>8</release>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
+				<version>2.22.2</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 				<configuration>
 					<showDeprecation>true</showDeprecation>
 					<compilerArgs>-Xlint:unchecked</compilerArgs>
-					<!-- Requires mvn 3.6 or later -->
+					<!-- Release directive requires mvn 3.6 and Java 9 or later -->
 					<release>8</release>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
 	</licenses>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>6</maven.compiler.source>
-		<maven.compiler.target>6</maven.compiler.target>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -47,6 +47,12 @@
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.seancfoley</groupId>
+			<artifactId>ipaddress</artifactId>
+			<version>5.3.1</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/org/tinyradius/attribute/IntegerAttribute.java
+++ b/src/main/java/org/tinyradius/attribute/IntegerAttribute.java
@@ -56,7 +56,7 @@ public class IntegerAttribute extends RadiusAttribute {
 				return name;
 		}
 		// Radius uses only unsigned values....
-		return Long.toString(((long)value & 0xffffffffl));
+		return Long.toString(((long)value & 0xffffffffL));
 	}
 	
 	/**
@@ -82,7 +82,7 @@ public class IntegerAttribute extends RadiusAttribute {
 		if (at != null) {
 			Integer val = at.getEnumeration(value);
 			if (val != null) {
-				setAttributeValue(val.intValue());
+				setAttributeValue(val);
 				return;
 			}
 		}

--- a/src/main/java/org/tinyradius/attribute/IpAttribute.java
+++ b/src/main/java/org/tinyradius/attribute/IpAttribute.java
@@ -48,7 +48,7 @@ public class IpAttribute extends RadiusAttribute {
 	 * @see org.tinyradius.attribute.RadiusAttribute#getAttributeValue()
 	 */
 	public String getAttributeValue() {
-		StringBuffer ip = new StringBuffer();
+		StringBuilder ip = new StringBuilder();
 		byte[] data = getAttributeData();
 		if (data == null || data.length != 4)
 			throw new RuntimeException("ip attribute: expected 4 bytes attribute data");
@@ -107,6 +107,7 @@ public class IpAttribute extends RadiusAttribute {
 	 * Sets the IP number represented by this IpAttribute
 	 * as a 32 bit unsigned number.
 	 * @param ip
+	 *           ip address
 	 */
 	public void setIpAsLong(long ip) {
 		byte[] data = new byte[4];

--- a/src/main/java/org/tinyradius/attribute/Ipv6Attribute.java
+++ b/src/main/java/org/tinyradius/attribute/Ipv6Attribute.java
@@ -4,7 +4,6 @@
  */
 package org.tinyradius.attribute;
 
-import java.util.StringTokenizer;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
 

--- a/src/main/java/org/tinyradius/attribute/RadiusAttribute.java
+++ b/src/main/java/org/tinyradius/attribute/RadiusAttribute.java
@@ -234,7 +234,7 @@ public class RadiusAttribute {
 		AttributeType at = dictionary.getAttributeTypeByCode(vendorId, attributeType);
 		if (at != null && at.getAttributeClass() != null) {
 			try {
-				attribute = (RadiusAttribute) at.getAttributeClass().newInstance();
+				attribute = at.getAttributeClass().newInstance();
 			}
 			catch (Exception e) {
 				// error instantiating class - should not occur

--- a/src/main/java/org/tinyradius/attribute/StringAttribute.java
+++ b/src/main/java/org/tinyradius/attribute/StringAttribute.java
@@ -6,7 +6,7 @@
  */
 package org.tinyradius.attribute;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This class represents a Radius attribute which only
@@ -36,11 +36,7 @@ public class StringAttribute extends RadiusAttribute {
 	 * @return a string
 	 */
 	public String getAttributeValue() {
-		try {
-			return new String(getAttributeData(), "UTF-8");
-		} catch (UnsupportedEncodingException uee) {
-			return new String(getAttributeData());
-		}
+		return new String(getAttributeData(), StandardCharsets.UTF_8);
 	}
 	
 	/**
@@ -50,11 +46,7 @@ public class StringAttribute extends RadiusAttribute {
 	public void setAttributeValue(String value) {
 		if (value == null)
 			throw new NullPointerException("string value not set");
-		try {
-			setAttributeData(value.getBytes("UTF-8"));
-		} catch (UnsupportedEncodingException uee) {
-			setAttributeData(value.getBytes());
-		}
+		setAttributeData(value.getBytes(StandardCharsets.UTF_8));
 	}
 	
 }

--- a/src/main/java/org/tinyradius/attribute/VendorSpecificAttribute.java
+++ b/src/main/java/org/tinyradius/attribute/VendorSpecificAttribute.java
@@ -10,7 +10,6 @@ package org.tinyradius.attribute;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import org.tinyradius.dictionary.AttributeType;
@@ -50,6 +49,7 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 	 * Sets the vendor ID of the child attributes.
 	 * 
 	 * @param childVendorId
+	 *           vendor ID of the child attributes
 	 */
 	public void setChildVendorId(int childVendorId) {
 		this.childVendorId = childVendorId;
@@ -73,8 +73,7 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 	 */
 	public void setDictionary(Dictionary dictionary) {
 		super.setDictionary(dictionary);
-		for (Iterator i = subAttributes.iterator(); i.hasNext();) {
-			RadiusAttribute attr = (RadiusAttribute) i.next();
+		for (RadiusAttribute attr : subAttributes) {
 			attr.setDictionary(dictionary);
 		}
 	}
@@ -87,7 +86,7 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 	 */
 	public void addSubAttribute(RadiusAttribute attribute) {
 		if (attribute.getVendorId() != getChildVendorId())
-			throw new IllegalArgumentException("sub attribut has incorrect vendor ID");
+			throw new IllegalArgumentException("sub attribute has incorrect vendor ID");
 
 		subAttributes.add(attribute);
 	}
@@ -137,24 +136,23 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 	 * 
 	 * @return List of RadiusAttribute objects
 	 */
-	public List getSubAttributes() {
+	public List<RadiusAttribute> getSubAttributes() {
 		return subAttributes;
 	}
 
 	/**
-	 * Returns all sub-attributes of this attribut which have the given type.
+	 * Returns all sub-attributes of this attribute which have the given type.
 	 * 
 	 * @param attributeType
 	 *            type of sub-attributes to get
 	 * @return list of RadiusAttribute objects, does not return null
 	 */
-	public List getSubAttributes(int attributeType) {
+	public List<RadiusAttribute> getSubAttributes(int attributeType) {
 		if (attributeType < 1 || attributeType > 255)
 			throw new IllegalArgumentException("sub-attribute type out of bounds");
 
-		LinkedList result = new LinkedList();
-		for (Iterator i = subAttributes.iterator(); i.hasNext();) {
-			RadiusAttribute a = (RadiusAttribute) i.next();
+		LinkedList<RadiusAttribute> result = new LinkedList<>();
+		for (RadiusAttribute a : subAttributes) {
 			if (attributeType == a.getAttributeType())
 				result.add(a);
 		}
@@ -169,17 +167,17 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 	 *            sub-attribute type
 	 * @return RadiusAttribute object or null if there is no such sub-attribute
 	 * @throws RuntimeException
-	 *             if there are multiple occurences of the
+	 *             if there are multiple occurrences of the
 	 *             requested sub-attribute type
 	 */
 	public RadiusAttribute getSubAttribute(int type) {
-		List attrs = getSubAttributes(type);
+		List<RadiusAttribute> attrs = getSubAttributes(type);
 		if (attrs.size() > 1)
 			throw new RuntimeException("multiple sub-attributes of requested type " + type);
 		else if (attrs.size() == 0)
 			return null;
 		else
-			return (RadiusAttribute) attrs.get(0);
+			return attrs.get(0);
 	}
 
 	/**
@@ -188,11 +186,10 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 	 * @param type
 	 *            attribute type name
 	 * @return RadiusAttribute object or null if there is no such attribute
-	 * @throws RadiusException
 	 * @throws RuntimeException
 	 *             if the attribute occurs multiple times
 	 */
-	public RadiusAttribute getSubAttribute(String type) throws RadiusException {
+	public RadiusAttribute getSubAttribute(String type) {
 		if (type == null || type.length() == 0)
 			throw new IllegalArgumentException("type name is empty");
 
@@ -218,7 +215,7 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 	 * @throws RuntimeException
 	 *             attribute occurs multiple times
 	 */
-	public String getSubAttributeValue(String type) throws RadiusException {
+	public String getSubAttributeValue(String type) {
 		RadiusAttribute attr = getSubAttribute(type);
 		if (attr == null) {
 			return null;
@@ -241,8 +238,7 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 
 		// write sub-attributes
 		try {
-			for (Iterator i = subAttributes.iterator(); i.hasNext();) {
-				RadiusAttribute a = (RadiusAttribute) i.next();
+			for (RadiusAttribute a : subAttributes) {
 				bos.write(a.writeAttribute());
 			}
 		}
@@ -305,7 +301,7 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 		if (pos != vsaLen)
 			throw new RadiusException("Vendor-Specific attribute malformed");
 
-		subAttributes = new ArrayList(count);
+		subAttributes = new ArrayList<>(count);
 		pos = 0;
 		while (pos < vsaLen) {
 			int subtype = data[(offset + 6) + pos] & 0x0ff;
@@ -327,7 +323,7 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 	 * @see org.tinyradius.attribute.RadiusAttribute#toString()
 	 */
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("Vendor-Specific: ");
 		int vendorId = getChildVendorId();
 		String vendorName = getDictionary().getVendorName(vendorId);
@@ -341,8 +337,7 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 			sb.append("vendor ID ");
 			sb.append(vendorId);
 		}
-		for (Iterator i = getSubAttributes().iterator(); i.hasNext();) {
-			RadiusAttribute attr = (RadiusAttribute) i.next();
+		for (RadiusAttribute attr : getSubAttributes()) {
 			sb.append("\n");
 			sb.append(attr.toString());
 		}
@@ -352,7 +347,7 @@ public class VendorSpecificAttribute extends RadiusAttribute {
 	/**
 	 * Sub attributes. Only set if isRawData == false.
 	 */
-	private List subAttributes = new ArrayList();
+	private List<RadiusAttribute> subAttributes = new ArrayList<>();
 
 	/**
 	 * Vendor ID of sub-attributes.

--- a/src/main/java/org/tinyradius/dictionary/AttributeType.java
+++ b/src/main/java/org/tinyradius/dictionary/AttributeType.java
@@ -26,7 +26,7 @@ public class AttributeType {
 	 *            RadiusAttribute descendant who handles
 	 *            attributes of this type
 	 */
-	public AttributeType(int code, String name, Class type) {
+	public AttributeType(int code, String name, Class<? extends RadiusAttribute> type) {
 		setTypeCode(code);
 		setName(name);
 		setAttributeClass(type);
@@ -44,7 +44,7 @@ public class AttributeType {
 	 * @param type
 	 *            sub-attribute class
 	 */
-	public AttributeType(int vendor, int code, String name, Class type) {
+	public AttributeType(int vendor, int code, String name, Class<? extends RadiusAttribute> type) {
 		setTypeCode(code);
 		setName(name);
 		setAttributeClass(type);
@@ -99,7 +99,7 @@ public class AttributeType {
 	 * 
 	 * @return class
 	 */
-	public Class getAttributeClass() {
+	public Class<? extends RadiusAttribute> getAttributeClass() {
 		return attributeClass;
 	}
 
@@ -107,7 +107,7 @@ public class AttributeType {
 	 * Sets the RadiusAttribute descendant class which represents
 	 * attributes of this type.
 	 */
-	public void setAttributeClass(Class type) {
+	public void setAttributeClass(Class<? extends RadiusAttribute> type) {
 		if (type == null)
 			throw new NullPointerException("type is null");
 		if (!RadiusAttribute.class.isAssignableFrom(type))
@@ -202,7 +202,7 @@ public class AttributeType {
 	private int vendorId = -1;
 	private int typeCode;
 	private String name;
-	private Class attributeClass;
+	private Class<? extends RadiusAttribute> attributeClass;
 	private Map<Integer,String> enumeration = null;
 
 }

--- a/src/main/java/org/tinyradius/dictionary/AttributeType.java
+++ b/src/main/java/org/tinyradius/dictionary/AttributeType.java
@@ -7,7 +7,6 @@
 package org.tinyradius.dictionary;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.tinyradius.attribute.RadiusAttribute;
 
@@ -145,7 +144,7 @@ public class AttributeType {
 	 */
 	public String getEnumeration(int value) {
 		if (enumeration != null) {
-			return (String) enumeration.get(new Integer(value));
+			return enumeration.get(value);
 		}
 		return null;
 	}
@@ -163,10 +162,9 @@ public class AttributeType {
 			throw new IllegalArgumentException("value is empty");
 		if (enumeration == null)
 			return null;
-		for (Iterator i = enumeration.entrySet().iterator(); i.hasNext();) {
-			Map.Entry e = (Map.Entry) i.next();
+		for (Map.Entry<Integer, String> e : enumeration.entrySet()) {
 			if (e.getValue().equals(value))
-				return (Integer) e.getKey();
+				return e.getKey();
 		}
 		return null;
 	}
@@ -183,8 +181,8 @@ public class AttributeType {
 		if (name == null || name.length() == 0)
 			throw new IllegalArgumentException("name is empty");
 		if (enumeration == null)
-			enumeration = new HashMap();
-		enumeration.put(new Integer(num), name);
+			enumeration = new HashMap<>();
+		enumeration.put(num, name);
 	}
 
 	/**
@@ -205,6 +203,6 @@ public class AttributeType {
 	private int typeCode;
 	private String name;
 	private Class attributeClass;
-	private Map enumeration = null;
+	private Map<Integer,String> enumeration = null;
 
 }

--- a/src/main/java/org/tinyradius/dictionary/DefaultDictionary.java
+++ b/src/main/java/org/tinyradius/dictionary/DefaultDictionary.java
@@ -37,9 +37,9 @@ extends MemoryDictionary{
 	private static final String DICTIONARY_RESOURCE = "org/tinyradius/dictionary/default_dictionary";
 	private static DefaultDictionary instance = null;
 
-	/**
+	/*
 	 * Creates the singleton instance of this object
-	 * and parses the classpath ressource.
+	 * and parses the classpath resource.
 	 */
 	static {
 		try {

--- a/src/main/java/org/tinyradius/dictionary/Dictionary.java
+++ b/src/main/java/org/tinyradius/dictionary/Dictionary.java
@@ -19,7 +19,7 @@ public interface Dictionary {
 	 * @param typeName name of the attribute type 
 	 * @return AttributeType object or null
 	 */
-	public AttributeType getAttributeTypeByName(String typeName);
+	AttributeType getAttributeTypeByName(String typeName);
 	
 	/**
 	 * Retrieves an attribute type by type code. This method
@@ -27,7 +27,7 @@ public interface Dictionary {
 	 * @param typeCode type code, 1-255
 	 * @return AttributeType object or null
 	 */
-	public AttributeType getAttributeTypeByCode(int typeCode);
+	AttributeType getAttributeTypeByCode(int typeCode);
 	
 	/**
 	 * Retrieves an attribute type for a vendor-specific
@@ -36,7 +36,7 @@ public interface Dictionary {
 	 * @param typeCode type code, 1-255
 	 * @return AttributeType object or null
 	 */
-	public AttributeType getAttributeTypeByCode(int vendorId, int typeCode);
+	AttributeType getAttributeTypeByCode(int vendorId, int typeCode);
 
 	/**
 	 * Retrieves the name of the vendor with the given
@@ -44,7 +44,7 @@ public interface Dictionary {
 	 * @param vendorId vendor number
 	 * @return vendor name or null
 	 */
-	public String getVendorName(int vendorId);
+	String getVendorName(int vendorId);
 	
 	/**
 	 * Retrieves the ID of the vendor with the given
@@ -52,6 +52,6 @@ public interface Dictionary {
 	 * @param vendorName name of the vendor
 	 * @return vendor ID or -1
 	 */
-	public int getVendorId(String vendorName);
+	int getVendorId(String vendorName);
 	
 }

--- a/src/main/java/org/tinyradius/dictionary/DictionaryParser.java
+++ b/src/main/java/org/tinyradius/dictionary/DictionaryParser.java
@@ -102,7 +102,7 @@ public class DictionaryParser {
 		String typeStr = tok.nextToken().trim();
 
 		// translate type to class
-		Class type;
+		Class<? extends RadiusAttribute> type;
 		if (code == VendorSpecificAttribute.VENDOR_SPECIFIC)
 			type = VendorSpecificAttribute.class;
 		else
@@ -143,7 +143,7 @@ public class DictionaryParser {
 		int code = Integer.parseInt(tok.nextToken().trim());
 		String typeStr = tok.nextToken().trim();
 
-		Class type = getAttributeTypeClass(code, typeStr);
+		Class<? extends RadiusAttribute> type = getAttributeTypeClass(code, typeStr);
 		AttributeType at = new AttributeType(Integer.parseInt(vendor), code, name, type);
 		dictionary.addAttributeType(at);
 	}
@@ -192,12 +192,11 @@ public class DictionaryParser {
 	 *            string|octets|integer|date|ipaddr|ipv6addr|ipv6prefix
 	 * @return RadiusAttribute class or descendant
 	 */
-	private static Class getAttributeTypeClass(int attributeType, String typeStr) {
-		Class type = RadiusAttribute.class;
+	private static Class<? extends RadiusAttribute> getAttributeTypeClass(int attributeType, String typeStr) {
+		// Default type is RadiusAttribute
+		Class<? extends RadiusAttribute> type = RadiusAttribute.class;
 		if (typeStr.equalsIgnoreCase("string"))
 			type = StringAttribute.class;
-		else if (typeStr.equalsIgnoreCase("octets"))
-			type = RadiusAttribute.class;
 		else if (typeStr.equalsIgnoreCase("integer") || typeStr.equalsIgnoreCase("date"))
 			type = IntegerAttribute.class;
 		else if (typeStr.equalsIgnoreCase("ipaddr"))

--- a/src/main/java/org/tinyradius/dictionary/MemoryDictionary.java
+++ b/src/main/java/org/tinyradius/dictionary/MemoryDictionary.java
@@ -8,7 +8,6 @@
 package org.tinyradius.dictionary;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -47,11 +46,11 @@ public class MemoryDictionary implements WritableDictionary {
 	 * @see org.tinyradius.dictionary.Dictionary#getAttributeTypeByCode(int, int)
 	 */
 	public AttributeType getAttributeTypeByCode(int vendorCode, int typeCode) {
-		Map vendorAttributes = (Map) attributesByCode.get(new Integer(vendorCode));
+		Map<Integer, AttributeType> vendorAttributes = attributesByCode.get(vendorCode);
 		if (vendorAttributes == null) {
 			return null;
 		}
-		return (AttributeType) vendorAttributes.get(new Integer(typeCode));
+		return vendorAttributes.get(typeCode);
 	}
 
 	/**
@@ -63,7 +62,7 @@ public class MemoryDictionary implements WritableDictionary {
 	 * @see org.tinyradius.dictionary.Dictionary#getAttributeTypeByName(java.lang.String)
 	 */
 	public AttributeType getAttributeTypeByName(String typeName) {
-		return (AttributeType) attributesByName.get(typeName);
+		return attributesByName.get(typeName);
 	}
 
 	/**
@@ -76,10 +75,9 @@ public class MemoryDictionary implements WritableDictionary {
 	 * @see org.tinyradius.dictionary.Dictionary#getVendorId(java.lang.String)
 	 */
 	public int getVendorId(String vendorName) {
-		for (Iterator i = vendorsByCode.entrySet().iterator(); i.hasNext();) {
-			Map.Entry e = (Map.Entry) i.next();
+		for (Map.Entry<Integer, String> e : vendorsByCode.entrySet()) {
 			if (e.getValue().equals(vendorName))
-				return ((Integer) e.getKey()).intValue();
+				return e.getKey();
 		}
 		return -1;
 	}
@@ -94,7 +92,7 @@ public class MemoryDictionary implements WritableDictionary {
 	 * @see org.tinyradius.dictionary.Dictionary#getVendorName(int)
 	 */
 	public String getVendorName(int vendorId) {
-		return (String) vendorsByCode.get(new Integer(vendorId));
+		return vendorsByCode.get(vendorId);
 	}
 
 	/**
@@ -114,7 +112,7 @@ public class MemoryDictionary implements WritableDictionary {
 			throw new IllegalArgumentException("duplicate vendor code");
 		if (vendorName == null || vendorName.length() == 0)
 			throw new IllegalArgumentException("vendor name empty");
-		vendorsByCode.put(new Integer(vendorId), vendorName);
+		vendorsByCode.put(vendorId, vendorName);
 	}
 
 	/**
@@ -129,18 +127,14 @@ public class MemoryDictionary implements WritableDictionary {
 		if (attributeType == null)
 			throw new IllegalArgumentException("attribute type must not be null");
 
-		Integer vendorId = new Integer(attributeType.getVendorId());
-		Integer typeCode = new Integer(attributeType.getTypeCode());
+		Integer vendorId = attributeType.getVendorId();
+		Integer typeCode = attributeType.getTypeCode();
 		String attributeName = attributeType.getName();
 
 		if (attributesByName.containsKey(attributeName))
 			throw new IllegalArgumentException("duplicate attribute name: " + attributeName);
 
-		Map vendorAttributes = (Map) attributesByCode.get(vendorId);
-		if (vendorAttributes == null) {
-			vendorAttributes = new HashMap();
-			attributesByCode.put(vendorId, vendorAttributes);
-		}
+		Map<Integer, AttributeType> vendorAttributes = attributesByCode.computeIfAbsent(vendorId, k -> new HashMap<>());
 		if (vendorAttributes.containsKey(typeCode))
 			throw new IllegalArgumentException("duplicate type code: " + typeCode);
 
@@ -148,8 +142,8 @@ public class MemoryDictionary implements WritableDictionary {
 		vendorAttributes.put(typeCode, attributeType);
 	}
 
-	private Map vendorsByCode = new HashMap(); // <Integer, String>
-	private Map attributesByCode = new HashMap(); // <Integer, <Integer, AttributeType>>
-	private Map attributesByName = new HashMap(); // <String, AttributeType>
+	private Map<Integer,String> vendorsByCode = new HashMap<>(); // <Integer, String>
+	private Map<Integer,Map<Integer,AttributeType>> attributesByCode = new HashMap<>(); // <Integer, <Integer, AttributeType>>
+	private Map<String,AttributeType> attributesByName = new HashMap<>(); // <String, AttributeType>
 
 }

--- a/src/main/java/org/tinyradius/dictionary/WritableDictionary.java
+++ b/src/main/java/org/tinyradius/dictionary/WritableDictionary.java
@@ -18,12 +18,12 @@ extends Dictionary {
 	 * @param vendorId vendor ID
 	 * @param vendorName name of the vendor
 	 */
-	public void addVendor(int vendorId, String vendorName);
+	void addVendor(int vendorId, String vendorName);
 
 	/**
 	 * Adds an AttributeType object to the dictionary.
 	 * @param attributeType AttributeType object
 	 */
-	public void addAttributeType(AttributeType attributeType);
+	void addAttributeType(AttributeType attributeType);
 
 }

--- a/src/main/java/org/tinyradius/packet/AccessRequest.java
+++ b/src/main/java/org/tinyradius/packet/AccessRequest.java
@@ -45,7 +45,7 @@ public class AccessRequest extends RadiusPacket {
 	 */
 	public static final String AUTH_EAP = "eap";
 
-	public static final Set AUTH_PROTOCOLS = new HashSet(Arrays.asList(AUTH_PAP, AUTH_CHAP, AUTH_MS_CHAP_V2, AUTH_EAP));
+	public static final Set<String> AUTH_PROTOCOLS = new HashSet<>(Arrays.asList(AUTH_PAP, AUTH_CHAP, AUTH_MS_CHAP_V2, AUTH_EAP));
 	
 	/**
 	 * Constructs an empty Access-Request packet.
@@ -56,11 +56,11 @@ public class AccessRequest extends RadiusPacket {
 
 	/**
 	 * Constructs an Access-Request packet, sets the
-	 * code, identifier and adds an User-Name and an
+	 * code, identifier and adds a User-Name and a
 	 * User-Password attribute (PAP).
 	 * 
 	 * @param userName
-	 *            user name
+	 *            username
 	 * @param userPassword
 	 *            user password
 	 */
@@ -74,7 +74,7 @@ public class AccessRequest extends RadiusPacket {
 	 * Sets the User-Name attribute of this Access-Request.
 	 * 
 	 * @param userName
-	 *            user name to set
+	 *            username to set
 	 */
 	public void setUserName(String userName) {
 		if (userName == null)
@@ -110,17 +110,17 @@ public class AccessRequest extends RadiusPacket {
 	}
 
 	/**
-	 * Retrieves the user name from the User-Name attribute.
+	 * Retrieves the username from the User-Name attribute.
 	 * 
-	 * @return user name
+	 * @return username
 	 */
 	public String getUserName() {
-		List attrs = getAttributes(USER_NAME);
-		if (attrs.size() < 1 || attrs.size() > 1)
+		List<RadiusAttribute> attrs = getAttributes(USER_NAME);
+		if (attrs.size() != 1)
 			throw new RuntimeException("exactly one User-Name attribute required");
 
-		RadiusAttribute ra = (RadiusAttribute) attrs.get(0);
-		return ((StringAttribute) ra).getAttributeValue();
+		RadiusAttribute ra = attrs.get(0);
+		return ra.getAttributeValue();
 	}
 
 	/**
@@ -152,6 +152,7 @@ public class AccessRequest extends RadiusPacket {
 	 * and CHAP.
 	 * 
 	 * @param plaintext
+	 *        Plain text password
 	 * @return true if the password is valid, false otherwise
 	 */
 	public boolean verifyPassword(String plaintext) throws RadiusException {
@@ -219,24 +220,26 @@ public class AccessRequest extends RadiusPacket {
 		// ok for proxied packets whose CHAP password is already encrypted
 		// throw new RuntimeException("no password set");
 
-		if (getAuthProtocol().equals(AUTH_PAP)) {
-			byte[] pass = encodePapPassword(RadiusUtil.getUtf8Bytes(this.password), RadiusUtil.getUtf8Bytes(sharedSecret));
-			removeAttributes(USER_PASSWORD);
-			addAttribute(new RadiusAttribute(USER_PASSWORD, pass));
-		}
-		else if (getAuthProtocol().equals(AUTH_CHAP)) {
-			byte[] challenge = createChapChallenge();
-			byte[] pass = encodeChapPassword(password, challenge);
-			removeAttributes(CHAP_PASSWORD);
-			removeAttributes(CHAP_CHALLENGE);
-			addAttribute(new RadiusAttribute(CHAP_PASSWORD, pass));
-			addAttribute(new RadiusAttribute(CHAP_CHALLENGE, challenge));
-		}
-		else if (getAuthProtocol().equals(AUTH_MS_CHAP_V2)) {
-			throw new RuntimeException("encoding not supported for " + AUTH_MS_CHAP_V2); 
-		}
-		else if (getAuthProtocol().equals(AUTH_EAP)) {
-			throw new RuntimeException("encoding not supported for " + AUTH_EAP); 
+		switch (getAuthProtocol()) {
+			case AUTH_PAP: {
+				byte[] pass = encodePapPassword(RadiusUtil.getUtf8Bytes(this.password), RadiusUtil.getUtf8Bytes(sharedSecret));
+				removeAttributes(USER_PASSWORD);
+				addAttribute(new RadiusAttribute(USER_PASSWORD, pass));
+				break;
+			}
+			case AUTH_CHAP: {
+				byte[] challenge = createChapChallenge();
+				byte[] pass = encodeChapPassword(password, challenge);
+				removeAttributes(CHAP_PASSWORD);
+				removeAttributes(CHAP_CHALLENGE);
+				addAttribute(new RadiusAttribute(CHAP_PASSWORD, pass));
+				addAttribute(new RadiusAttribute(CHAP_CHALLENGE, challenge));
+				break;
+			}
+			case AUTH_MS_CHAP_V2:
+				throw new RuntimeException("encoding not supported for " + AUTH_MS_CHAP_V2);
+			case AUTH_EAP:
+				throw new RuntimeException("encoding not supported for " + AUTH_EAP);
 		}
 	}
 
@@ -254,7 +257,7 @@ public class AccessRequest extends RadiusPacket {
 		// to 128 bytes. If it isn't a multiple of 16 bytes fill it out with zeroes
 		// to make it a multiple of 16 bytes. If it is greater than 128 bytes
 		// truncate it at 128.
-		byte[] userPassBytes = null;
+		byte[] userPassBytes;
 		if (userPass.length > 128) {
 			userPassBytes = new byte[128];
 			System.arraycopy(userPass, 0, userPassBytes, 0, 128);
@@ -264,7 +267,7 @@ public class AccessRequest extends RadiusPacket {
 		}
 
 		// declare the byte array to hold the final product
-		byte[] encryptedPass = null;
+		byte[] encryptedPass;
 		if (userPassBytes.length < 128) {
 			if (userPassBytes.length % 16 == 0) {
 				// tt is already a multiple of 16 bytes
@@ -437,7 +440,7 @@ public class AccessRequest extends RadiusPacket {
 	/**
 	 * Random generator
 	 */
-	private static SecureRandom random = new SecureRandom();
+	private static final SecureRandom random = new SecureRandom();
 
 	/**
 	 * Radius type code for Radius attribute User-Name
@@ -478,6 +481,6 @@ public class AccessRequest extends RadiusPacket {
 	/**
 	 * Logger for logging information about malformed packets
 	 */
-	private static Log logger = LogFactory.getLog(AccessRequest.class);
+	private static final Log logger = LogFactory.getLog(AccessRequest.class);
 
 }

--- a/src/main/java/org/tinyradius/packet/AccessRequest.java
+++ b/src/main/java/org/tinyradius/packet/AccessRequest.java
@@ -297,7 +297,7 @@ public class AccessRequest extends RadiusPacket {
 				md5.update(encryptedPass, i - 16, 16);
 			}
 
-			byte bn[] = md5.digest();
+			byte[] bn = md5.digest();
 
 			// perform the XOR as specified by RFC 2865.
 			for (int j = 0; j < 16; j++)
@@ -330,7 +330,7 @@ public class AccessRequest extends RadiusPacket {
 			md5.reset();
 			md5.update(sharedSecret);
 			md5.update(i == 0 ? getAuthenticator() : lastBlock);
-			byte bn[] = md5.digest();
+			byte[] bn = md5.digest();
 
 			System.arraycopy(encryptedPass, i, lastBlock, 0, 16);
 

--- a/src/main/java/org/tinyradius/packet/AccountingRequest.java
+++ b/src/main/java/org/tinyradius/packet/AccountingRequest.java
@@ -50,7 +50,7 @@ public class AccountingRequest extends RadiusPacket {
 	 * Constructs an Accounting-Request packet to be sent to a Radius server.
 	 * 
 	 * @param userName
-	 *            user name
+	 *            username
 	 * @param acctStatusType
 	 *            ACCT_STATUS_TYPE_*
 	 */
@@ -69,10 +69,10 @@ public class AccountingRequest extends RadiusPacket {
 	}
 
 	/**
-	 * Sets the User-Name attribute of this Accountnig-Request.
+	 * Sets the User-Name attribute of this Accounting-Request.
 	 * 
 	 * @param userName
-	 *            user name to set
+	 *            username to set
 	 */
 	public void setUserName(String userName) {
 		if (userName == null)
@@ -85,22 +85,23 @@ public class AccountingRequest extends RadiusPacket {
 	}
 
 	/**
-	 * Retrieves the user name from the User-Name attribute.
+	 * Retrieves the username from the User-Name attribute.
 	 * 
-	 * @return user name
+	 * @return username
 	 * @throws RadiusException
+	 *            Radius Exception
 	 */
 	public String getUserName() throws RadiusException {
-		List attrs = getAttributes(USER_NAME);
-		if (attrs.size() < 1 || attrs.size() > 1)
+		List<RadiusAttribute> attrs = getAttributes(USER_NAME);
+		if (attrs.size() != 1)
 			throw new RuntimeException("exactly one User-Name attribute required");
 
-		RadiusAttribute ra = (RadiusAttribute) attrs.get(0);
-		return ((StringAttribute) ra).getAttributeValue();
+		RadiusAttribute ra = attrs.get(0);
+		return ra.getAttributeValue();
 	}
 
 	/**
-	 * Sets the Acct-Status-Type attribute of this Accountnig-Request.
+	 * Sets the Acct-Status-Type attribute of this Accounting-Request.
 	 * 
 	 * @param acctStatusType
 	 *            ACCT_STATUS_TYPE_* to set
@@ -113,10 +114,11 @@ public class AccountingRequest extends RadiusPacket {
 	}
 
 	/**
-	 * Retrieves the user name from the User-Name attribute.
+	 * Retrieves the username from the User-Name attribute.
 	 * 
-	 * @return user name
+	 * @return username
 	 * @throws RadiusException
+	 *           Radius Exception
 	 */
 	public int getAcctStatusType() throws RadiusException {
 		RadiusAttribute ra = getAttribute(ACCT_STATUS_TYPE);

--- a/src/main/java/org/tinyradius/packet/RadiusPacket.java
+++ b/src/main/java/org/tinyradius/packet/RadiusPacket.java
@@ -17,7 +17,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import org.tinyradius.attribute.RadiusAttribute;
@@ -80,7 +79,7 @@ public class RadiusPacket {
 	 *            packet type
 	 */
 	public RadiusPacket(final int type) {
-		this(type, getNextPacketIdentifier(), new ArrayList());
+		this(type, getNextPacketIdentifier(), new ArrayList<>());
 	}
 
 	/**
@@ -93,7 +92,7 @@ public class RadiusPacket {
 	 *            packet identifier
 	 */
 	public RadiusPacket(final int type, final int identifier) {
-		this(type, identifier, new ArrayList());
+		this(type, identifier, new ArrayList<>());
 	}
 
 	/**
@@ -107,7 +106,7 @@ public class RadiusPacket {
 	 * @param attributes
 	 *            list of RadiusAttribute objects
 	 */
-	public RadiusPacket(final int type, final int identifier, final List attributes) {
+	public RadiusPacket(final int type, final int identifier, final List<RadiusAttribute> attributes) {
 		setPacketType(type);
 		setPacketIdentifier(identifier);
 		setAttributes(attributes);
@@ -226,14 +225,13 @@ public class RadiusPacket {
 	 * @param attributes
 	 *            list of RadiusAttribute objects
 	 */
-	public void setAttributes(List attributes) {
+	public void setAttributes(List<RadiusAttribute> attributes) {
 		if (attributes == null)
 			throw new NullPointerException("attributes list is null");
 
-		for (Iterator i = attributes.iterator(); i.hasNext();) {
-			Object element = i.next();
-			if (!(element instanceof RadiusAttribute))
-				throw new IllegalArgumentException("attribute not an instance of RadiusAttribute");
+		for (RadiusAttribute radiusAttribute : attributes) {
+			if (radiusAttribute == null)
+				throw new NullPointerException("attributes list contains a null");
 		}
 
 		this.attributes = attributes;
@@ -241,7 +239,7 @@ public class RadiusPacket {
 
 	/**
 	 * Adds a Radius attribute to this packet. Can also be used
-	 * to add Vendor-Specific sub-attributes. If a attribute with
+	 * to add Vendor-Specific sub-attributes. If an attribute with
 	 * a vendor code != -1 is passed in, a VendorSpecificAttribute
 	 * is created for the sub-attribute.
 	 * 
@@ -252,9 +250,9 @@ public class RadiusPacket {
 		if (attribute == null)
 			throw new NullPointerException("attribute is null");
 		attribute.setDictionary(getDictionary());
-		if (attribute.getVendorId() == -1)
+		if (attribute.getVendorId() == -1) {
 			this.attributes.add(attribute);
-		else {
+		} else {
 			VendorSpecificAttribute vsa = new VendorSpecificAttribute(attribute.getVendorId());
 			vsa.addSubAttribute(attribute);
 			this.attributes.add(vsa);
@@ -263,7 +261,7 @@ public class RadiusPacket {
 
 	/**
 	 * Adds a Radius attribute to this packet.
-	 * Uses AttributeTypes to lookup the type code and converts
+	 * Uses AttributeTypes to look up the type code and converts
 	 * the value.
 	 * Can also be used to add sub-attributes.
 	 * 
@@ -302,10 +300,9 @@ public class RadiusPacket {
 		}
 		else {
 			// remove Vendor-Specific sub-attribute
-			List vsas = getVendorAttributes(attribute.getVendorId());
-			for (Iterator i = vsas.iterator(); i.hasNext();) {
-				VendorSpecificAttribute vsa = (VendorSpecificAttribute) i.next();
-				List sas = vsa.getSubAttributes();
+			List<VendorSpecificAttribute> vsas = getVendorAttributes(attribute.getVendorId());
+			for (VendorSpecificAttribute vsa : vsas) {
+				List<RadiusAttribute> sas = vsa.getSubAttributes();
 				if (sas.contains(attribute)) {
 					vsa.removeSubAttribute(attribute);
 					if (sas.size() == 1)
@@ -328,27 +325,22 @@ public class RadiusPacket {
 		if (type < 1 || type > 255)
 			throw new IllegalArgumentException("attribute type out of bounds");
 
-		Iterator i = attributes.iterator();
-		while (i.hasNext()) {
-			RadiusAttribute attribute = (RadiusAttribute) i.next();
-			if (attribute.getAttributeType() == type)
-				i.remove();
-		}
+		attributes.removeIf(attribute -> attribute.getAttributeType() == type);
 	}
 
 	/**
-	 * Removes the last occurence of the attribute of the given
+	 * Removes the last occurrence of the attribute of the given
 	 * type from the packet.
 	 * 
 	 * @param type
 	 *            attribute type code
 	 */
 	public void removeLastAttribute(int type) {
-		List attrs = getAttributes(type);
+		List<RadiusAttribute> attrs = getAttributes(type);
 		if (attrs == null || attrs.size() == 0)
 			return;
 
-		RadiusAttribute lastAttribute = (RadiusAttribute) attrs.get(attrs.size() - 1);
+		RadiusAttribute lastAttribute = attrs.get(attrs.size() - 1);
 		removeAttribute(lastAttribute);
 	}
 
@@ -367,16 +359,10 @@ public class RadiusPacket {
 			return;
 		}
 
-		List vsas = getVendorAttributes(vendorId);
-		for (Iterator i = vsas.iterator(); i.hasNext();) {
-			VendorSpecificAttribute vsa = (VendorSpecificAttribute) i.next();
-
-			List sas = vsa.getSubAttributes();
-			for (Iterator j = sas.iterator(); j.hasNext();) {
-				RadiusAttribute attr = (RadiusAttribute) j.next();
-				if (attr.getAttributeType() == typeCode && attr.getVendorId() == vendorId)
-					j.remove();
-			}
+		List<VendorSpecificAttribute> vsas = getVendorAttributes(vendorId);
+		for (VendorSpecificAttribute vsa : vsas) {
+			List<RadiusAttribute> sas = vsa.getSubAttributes();
+			sas.removeIf(attr -> attr.getAttributeType() == typeCode && attr.getVendorId() == vendorId);
 			if (sas.size() == 0)
 				// removed the last sub-attribute
 				// --> remove the whole Vendor-Specific attribute
@@ -392,13 +378,12 @@ public class RadiusPacket {
 	 *            type of attributes to get
 	 * @return list of RadiusAttribute objects, does not return null
 	 */
-	public List getAttributes(int attributeType) {
+	public List<RadiusAttribute> getAttributes(int attributeType) {
 		if (attributeType < 1 || attributeType > 255)
 			throw new IllegalArgumentException("attribute type out of bounds");
 
-		LinkedList result = new LinkedList();
-		for (Iterator i = attributes.iterator(); i.hasNext();) {
-			RadiusAttribute a = (RadiusAttribute) i.next();
+		LinkedList<RadiusAttribute> result = new LinkedList<>();
+		for (RadiusAttribute a : attributes) {
 			if (attributeType == a.getAttributeType())
 				result.add(a);
 		}
@@ -416,17 +401,15 @@ public class RadiusPacket {
 	 *            attribute type code
 	 * @return list of RadiusAttribute objects, never null
 	 */
-	public List getAttributes(int vendorId, int attributeType) {
+	public List<RadiusAttribute> getAttributes(int vendorId, int attributeType) {
 		if (vendorId == -1)
 			return getAttributes(attributeType);
 
-		LinkedList result = new LinkedList();
-		List vsas = getVendorAttributes(vendorId);
-		for (Iterator i = vsas.iterator(); i.hasNext();) {
-			VendorSpecificAttribute vsa = (VendorSpecificAttribute) i.next();
-			List sas = vsa.getSubAttributes();
-			for (Iterator j = sas.iterator(); j.hasNext();) {
-				RadiusAttribute attr = (RadiusAttribute) j.next();
+		LinkedList<RadiusAttribute> result = new LinkedList<>();
+		List<VendorSpecificAttribute> vsas = getVendorAttributes(vendorId);
+		for (VendorSpecificAttribute vsa : vsas) {
+			List<RadiusAttribute> sas = vsa.getSubAttributes();
+			for (RadiusAttribute attr : sas) {
 				if (attr.getAttributeType() == attributeType && attr.getVendorId() == vendorId)
 					result.add(attr);
 			}
@@ -441,7 +424,7 @@ public class RadiusPacket {
 	 * 
 	 * @return List of RadiusAttribute objects
 	 */
-	public List getAttributes() {
+	public List<RadiusAttribute> getAttributes() {
 		return attributes;
 	}
 
@@ -453,17 +436,17 @@ public class RadiusPacket {
 	 *            attribute type
 	 * @return RadiusAttribute object or null if there is no such attribute
 	 * @throws RuntimeException
-	 *             if there are multiple occurences of the
+	 *             if there are multiple occurrences of the
 	 *             requested attribute type
 	 */
 	public RadiusAttribute getAttribute(int type) {
-		List attrs = getAttributes(type);
+		List<RadiusAttribute> attrs = getAttributes(type);
 		if (attrs.size() > 1)
 			throw new RuntimeException("multiple attributes of requested type " + type);
 		else if (attrs.size() == 0)
 			return null;
 		else
-			return (RadiusAttribute) attrs.get(0);
+			return attrs.get(0);
 	}
 
 	/**
@@ -476,20 +459,20 @@ public class RadiusPacket {
 	 *            attribute type
 	 * @return RadiusAttribute object or null if there is no such attribute
 	 * @throws RuntimeException
-	 *             if there are multiple occurences of the
+	 *             if there are multiple occurrences of the
 	 *             requested attribute type
 	 */
 	public RadiusAttribute getAttribute(int vendorId, int type) {
 		if (vendorId == -1)
 			return getAttribute(type);
 
-		List attrs = getAttributes(vendorId, type);
+		List<RadiusAttribute> attrs = getAttributes(vendorId, type);
 		if (attrs.size() > 1)
 			throw new RuntimeException("multiple attributes of requested type " + type);
 		else if (attrs.size() == 0)
 			return null;
 		else
-			return (RadiusAttribute) attrs.get(0);
+			return attrs.get(0);
 	}
 
 	/**
@@ -542,10 +525,9 @@ public class RadiusPacket {
 	 *            vendor ID of the attribute(s)
 	 * @return List with VendorSpecificAttribute objects, never null
 	 */
-	public List getVendorAttributes(int vendorId) {
-		LinkedList result = new LinkedList();
-		for (Iterator i = attributes.iterator(); i.hasNext();) {
-			RadiusAttribute a = (RadiusAttribute) i.next();
+	public List<VendorSpecificAttribute> getVendorAttributes(int vendorId) {
+		LinkedList<VendorSpecificAttribute> result = new LinkedList<>();
+		for (RadiusAttribute a : attributes) {
 			if (a instanceof VendorSpecificAttribute) {
 				VendorSpecificAttribute vsa = (VendorSpecificAttribute) a;
 				if (vsa.getChildVendorId() == vendorId)
@@ -568,8 +550,8 @@ public class RadiusPacket {
 	 * @see #getVendorAttributes(int)
 	 */
 	public VendorSpecificAttribute getVendorAttribute(int vendorId) {
-		for (Iterator i = getAttributes(VendorSpecificAttribute.VENDOR_SPECIFIC).iterator(); i.hasNext();) {
-			VendorSpecificAttribute vsa = (VendorSpecificAttribute) i.next();
+		for (RadiusAttribute radiusAttribute : getAttributes(VendorSpecificAttribute.VENDOR_SPECIFIC)) {
+			VendorSpecificAttribute vsa = (VendorSpecificAttribute) radiusAttribute;
 			if (vsa.getChildVendorId() == vendorId)
 				return vsa;
 		}
@@ -612,7 +594,7 @@ public class RadiusPacket {
 
 	/**
 	 * Reads a Radius request packet from the given input stream and
-	 * creates an appropiate RadiusPacket descendant object.
+	 * creates an appropriate RadiusPacket descendant object.
 	 * Reads in all attributes and returns the object.
 	 * Decodes the encrypted fields and attributes of the packet.
 	 * 
@@ -634,7 +616,7 @@ public class RadiusPacket {
 
 	/**
 	 * Reads a Radius response packet from the given input stream and
-	 * creates an appropiate RadiusPacket descendant object.
+	 * creates an appropriate RadiusPacket descendant object.
 	 * Reads in all attributes and returns the object.
 	 * Checks the packet authenticator.
 	 * 
@@ -656,7 +638,7 @@ public class RadiusPacket {
 
 	/**
 	 * Reads a Radius request packet from the given input stream and
-	 * creates an appropiate RadiusPacket descendant object.
+	 * creates an appropriate RadiusPacket descendant object.
 	 * Reads in all attributes and returns the object.
 	 * Decodes the encrypted fields and attributes of the packet.
 	 * 
@@ -678,7 +660,7 @@ public class RadiusPacket {
 
 	/**
 	 * Reads a Radius response packet from the given input stream and
-	 * creates an appropiate RadiusPacket descendant object.
+	 * creates an appropriate RadiusPacket descendant object.
 	 * Reads in all attributes and returns the object.
 	 * Checks the packet authenticator.
 	 * 
@@ -718,8 +700,7 @@ public class RadiusPacket {
 
 	/**
 	 * Creates a RadiusPacket object. Depending on the passed type, an
-	 * appropriate packet is created. Also sets the type, and the
-	 * the packet identifier.
+	 * appropriate packet is created. Also sets the type, and the packet identifier.
 	 * 
 	 * @param type
 	 *            packet type
@@ -753,12 +734,11 @@ public class RadiusPacket {
 	 * @see java.lang.Object#toString()
 	 */
 	public String toString() {
-		StringBuffer s = new StringBuffer();
+		StringBuilder s = new StringBuilder();
 		s.append(getPacketTypeName());
 		s.append(", ID ");
 		s.append(packetIdentifier);
-		for (Iterator i = attributes.iterator(); i.hasNext();) {
-			RadiusAttribute attr = (RadiusAttribute) i.next();
+		for (RadiusAttribute attr : attributes) {
 			s.append("\n");
 			s.append(attr.toString());
 		}
@@ -781,7 +761,7 @@ public class RadiusPacket {
 
 	/**
 	 * Sets the authenticator to be used for this Radius packet.
-	 * This method should seldomly be used.
+	 * This method should seldom be used.
 	 * Authenticators are created and managed by this class internally.
 	 * 
 	 * @param authenticator
@@ -811,8 +791,7 @@ public class RadiusPacket {
 	 */
 	public void setDictionary(Dictionary dictionary) {
 		this.dictionary = dictionary;
-		for (Iterator i = attributes.iterator(); i.hasNext();) {
-			RadiusAttribute attr = (RadiusAttribute) i.next();
+		for (RadiusAttribute attr : attributes) {
 			attr.setDictionary(dictionary);
 		}
 	}
@@ -881,6 +860,8 @@ public class RadiusPacket {
 	 * authenticator.
 	 * 
 	 * @param sharedSecret
+	 *           shared secret that secures the communication
+	 *           with the other Radius server/client
 	 */
 	protected void encodeRequestAttributes(String sharedSecret) {
 	}
@@ -950,7 +931,7 @@ public class RadiusPacket {
 
 	/**
 	 * Reads a Radius packet from the given input stream and
-	 * creates an appropiate RadiusPacket descendant object.
+	 * creates an appropriate RadiusPacket descendant object.
 	 * Reads in all attributes and returns the object.
 	 * Decodes the encrypted fields and attributes of the packet.
 	 * 
@@ -1004,7 +985,6 @@ public class RadiusPacket {
 
 		// check and count attributes
 		int pos = 0;
-		int attributeCount = 0;
 		while (pos < attributeData.length) {
 			if (pos + 1 >= attributeData.length)
 				throw new RadiusException("bad packet: attribute length mismatch");
@@ -1012,7 +992,6 @@ public class RadiusPacket {
 			if (attributeLength < 2)
 				throw new RadiusException("bad packet: invalid attribute length");
 			pos += attributeLength;
-			attributeCount++;
 		}
 		if (pos != attributeData.length)
 			throw new RadiusException("bad packet: attribute length mismatch");
@@ -1051,7 +1030,7 @@ public class RadiusPacket {
 
 	/**
 	 * Checks the request authenticator against the supplied shared secret.
-	 * Overriden by AccountingRequest to handle special accounting request
+	 * Overridden by AccountingRequest to handle special accounting request
 	 * authenticators. There is no way to check request authenticators for
 	 * authentication requests as they contain secret bytes.
 	 * 
@@ -1062,24 +1041,28 @@ public class RadiusPacket {
 	 * @param attributes
 	 *            request attribute data
 	 * @throws RadiusException
+	 *            RadiusException
 	 */
 	protected void checkRequestAuthenticator(String sharedSecret, int packetLength, byte[] attributes) throws RadiusException {
 	}
 
 	/**
-	 * Can be overriden to decode encoded request attributes such as
+	 * Can be overridden to decode encoded request attributes such as
 	 * User-Password. This method may use getAuthenticator() to get the
 	 * request authenticator.
 	 * 
 	 * @param sharedSecret
+	 *            shared secret that secures the communication
+	 *            with the other Radius server/client
 	 * @throws RadiusException
+	 *            RadiusException
 	 */
 	protected void decodeRequestAttributes(String sharedSecret) throws RadiusException {
 	}
 
 	/**
 	 * This method checks the authenticator of this Radius packet. This method
-	 * may be overriden to include special attributes in the authenticator check.
+	 * may be overridden to include special attributes in the authenticator check.
 	 * 
 	 * @param sharedSecret
 	 *            shared secret to be used to encrypt the authenticator
@@ -1125,8 +1108,7 @@ public class RadiusPacket {
 	 */
 	protected byte[] getAttributeBytes() throws IOException {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream(MAX_PACKET_LENGTH);
-		for (Iterator i = attributes.iterator(); i.hasNext();) {
-			RadiusAttribute a = (RadiusAttribute) i.next();
+		for (RadiusAttribute a : attributes) {
 			bos.write(a.writeAttribute());
 		}
 		bos.flush();
@@ -1146,7 +1128,7 @@ public class RadiusPacket {
 	/**
 	 * Attributes for this packet.
 	 */
-	private List attributes = new ArrayList();
+	private List<RadiusAttribute> attributes = new ArrayList<>();
 
 	/**
 	 * MD5 digest.
@@ -1171,6 +1153,6 @@ public class RadiusPacket {
 	/**
 	 * Random number generator.
 	 */
-	private static SecureRandom random = new SecureRandom();
+	private static final SecureRandom random = new SecureRandom();
 
 }

--- a/src/main/java/org/tinyradius/packet/RadiusPacket.java
+++ b/src/main/java/org/tinyradius/packet/RadiusPacket.java
@@ -549,6 +549,7 @@ public class RadiusPacket {
 	 * @deprecated use getVendorAttributes(int)
 	 * @see #getVendorAttributes(int)
 	 */
+	@Deprecated
 	public VendorSpecificAttribute getVendorAttribute(int vendorId) {
 		for (RadiusAttribute radiusAttribute : getAttributes(VendorSpecificAttribute.VENDOR_SPECIFIC)) {
 			VendorSpecificAttribute vsa = (VendorSpecificAttribute) radiusAttribute;

--- a/src/main/java/org/tinyradius/proxy/RadiusProxy.java
+++ b/src/main/java/org/tinyradius/proxy/RadiusProxy.java
@@ -107,6 +107,7 @@ public abstract class RadiusProxy extends RadiusServer {
 	 * @param socketTimeout
 	 *            socket timeout, >0 ms
 	 * @throws SocketException
+	 *            Socket Exception
 	 */
 	public void setSocketTimeout(int socketTimeout) throws SocketException {
 		super.setSocketTimeout(socketTimeout);
@@ -119,6 +120,7 @@ public abstract class RadiusProxy extends RadiusServer {
 	 * 
 	 * @return socket
 	 * @throws SocketException
+	 *            Socket Exception
 	 */
 	protected DatagramSocket getProxySocket() throws SocketException {
 		if (proxySocket == null) {
@@ -167,17 +169,18 @@ public abstract class RadiusProxy extends RadiusServer {
 	 * @param remote
 	 *            the server the packet arrived from
 	 * @throws IOException
+	 *            IO Exception
 	 */
 	protected void proxyPacketReceived(RadiusPacket packet, InetSocketAddress remote) throws IOException, RadiusException {
 		// retrieve my Proxy-State attribute (the last)
-		List proxyStates = packet.getAttributes(33);
+		List<RadiusAttribute> proxyStates = packet.getAttributes(33);
 		if (proxyStates == null || proxyStates.size() == 0)
 			throw new RadiusException("proxy packet without Proxy-State attribute");
-		RadiusAttribute proxyState = (RadiusAttribute) proxyStates.get(proxyStates.size() - 1);
+		RadiusAttribute proxyState = proxyStates.get(proxyStates.size() - 1);
 
 		// retrieve proxy connection from cache
 		String state = new String(proxyState.getAttributeData());
-		RadiusProxyConnection proxyConnection = (RadiusProxyConnection) proxyConnections.remove(state);
+		RadiusProxyConnection proxyConnection = proxyConnections.remove(state);
 		if (proxyConnection == null) {
 			logger.warn("received packet on proxy port without saved proxy connection - duplicate?");
 			return;
@@ -214,9 +217,10 @@ public abstract class RadiusProxy extends RadiusServer {
 	 * 
 	 * @param packet
 	 *            the packet to proxy
-	 * @param proxyCon
+	 * @param proxyConnection
 	 *            the RadiusProxyConnection for this packet
 	 * @throws IOException
+	 *            IO Exception
 	 */
 	protected void proxyPacket(RadiusPacket packet, RadiusProxyConnection proxyConnection) throws IOException {
 		synchronized (RadiusProxy.class) {
@@ -261,10 +265,10 @@ public abstract class RadiusProxy extends RadiusServer {
 	 * without a received response.
 	 * Key: Proxy Index (String), Value: RadiusProxyConnection
 	 */
-	private Map proxyConnections = new HashMap();
+	private Map<String,RadiusProxyConnection> proxyConnections = new HashMap<>();
 
 	private int proxyPort = 1814;
 	private DatagramSocket proxySocket = null;
-	private static Log logger = LogFactory.getLog(RadiusProxy.class);
+	private static final Log logger = LogFactory.getLog(RadiusProxy.class);
 
 }

--- a/src/main/java/org/tinyradius/test/TestDictionary.java
+++ b/src/main/java/org/tinyradius/test/TestDictionary.java
@@ -6,15 +6,11 @@
  */
 package org.tinyradius.test;
 
-import java.io.FileInputStream;
-import java.io.InputStream;
-
 import org.tinyradius.attribute.IpAttribute;
 import org.tinyradius.attribute.Ipv6Attribute;
 import org.tinyradius.attribute.Ipv6PrefixAttribute;
 import org.tinyradius.dictionary.Dictionary;
 import org.tinyradius.dictionary.DefaultDictionary;
-import org.tinyradius.dictionary.DictionaryParser;
 import org.tinyradius.packet.AccessRequest;
 
 /**

--- a/src/main/java/org/tinyradius/test/TestServer.java
+++ b/src/main/java/org/tinyradius/test/TestServer.java
@@ -7,7 +7,6 @@
  */
 package org.tinyradius.test;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import org.tinyradius.packet.AccessRequest;
 import org.tinyradius.packet.RadiusPacket;
@@ -22,9 +21,10 @@ import org.tinyradius.util.RadiusServer;
 public class TestServer {
 
 	/**
-	 * @throws IOException
+	 * @throws Exception
+	 *           Exception
 	 */
-	public static void main(String[] args) throws IOException, Exception {
+	public static void main(String[] args) throws Exception {
 		RadiusServer server = new RadiusServer() {
 			// Authorize localhost/testing123
 			public String getSharedSecret(InetSocketAddress client) {

--- a/src/main/java/org/tinyradius/util/RadiusClient.java
+++ b/src/main/java/org/tinyradius/util/RadiusClient.java
@@ -59,7 +59,7 @@ public class RadiusClient {
 	 * Authenticates a user via PAP.
 	 * 
 	 * @param userName
-	 *            user name
+	 *            username
 	 * @param password
 	 *            password
 	 * @return true if authentication is successful, false otherwise
@@ -77,7 +77,7 @@ public class RadiusClient {
 	 * Authenticates a user.
 	 * 
 	 * @param userName
-	 *            user name
+	 *            username
 	 * @param password
 	 *            password
 	 * @param protocol
@@ -251,10 +251,11 @@ public class RadiusClient {
 	 * @param socketTimeout
 	 *            timeout, ms, >0
 	 * @throws SocketException
+	 *            Socket Exception
 	 */
 	public void setSocketTimeout(int socketTimeout) throws SocketException {
 		if (socketTimeout < 1)
-			throw new IllegalArgumentException("socket tiemout must be positive");
+			throw new IllegalArgumentException("socket timeout must be positive");
 		this.socketTimeout = socketTimeout;
 		if (serverSocket != null)
 			serverSocket.setSoTimeout(socketTimeout);
@@ -368,6 +369,7 @@ public class RadiusClient {
 	 * 
 	 * @return local socket
 	 * @throws SocketException
+	 *            Socket Exception
 	 */
 	protected DatagramSocket getSocket() throws SocketException {
 		if (serverSocket == null || serverSocket.isClosed()) {
@@ -378,7 +380,7 @@ public class RadiusClient {
 	}
 
 	/**
-	 * Creates a datagram packet from a RadiusPacket to be send.
+	 * Creates a datagram packet from a RadiusPacket to be sent.
 	 * 
 	 * @param packet
 	 *            RadiusPacket
@@ -386,6 +388,7 @@ public class RadiusClient {
 	 *            destination port number
 	 * @return new datagram packet
 	 * @throws IOException
+	 *            IO Exception
 	 */
 	protected DatagramPacket makeDatagramPacket(RadiusPacket packet, int port) throws IOException {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -393,8 +396,7 @@ public class RadiusClient {
 		byte[] data = bos.toByteArray();
 
 		InetAddress address = InetAddress.getByName(getHostName());
-		DatagramPacket datagram = new DatagramPacket(data, data.length, address, port);
-		return datagram;
+		return new DatagramPacket(data, data.length, address, port);
 	}
 
 	/**
@@ -419,6 +421,6 @@ public class RadiusClient {
 	private int retryCount = 3;
 	private int socketTimeout = 3000;
 	private String authProtocol = AccessRequest.AUTH_PAP;
-	private static Log logger = LogFactory.getLog(RadiusClient.class);
+	private static final Log logger = LogFactory.getLog(RadiusClient.class);
 
 }

--- a/src/main/java/org/tinyradius/util/RadiusClient.java
+++ b/src/main/java/org/tinyradius/util/RadiusClient.java
@@ -313,8 +313,7 @@ public class RadiusClient {
 		DatagramPacket packetIn = new DatagramPacket(new byte[RadiusPacket.MAX_PACKET_LENGTH], RadiusPacket.MAX_PACKET_LENGTH);
 		DatagramPacket packetOut = makeDatagramPacket(request, port);
 
-		DatagramSocket socket = getSocket();
-		try {
+		try (DatagramSocket socket = getSocket()) {
 			for (int i = 1; i <= getRetryCount(); i++) {
 				try {
 					socket.send(packetOut);
@@ -337,8 +336,6 @@ public class RadiusClient {
 					// calculated again (call makeDatagramPacket)
 				}
 			}
-		}finally {
-			socket.close();
 		}
 
 		return null;

--- a/src/main/java/org/tinyradius/util/RadiusServer.java
+++ b/src/main/java/org/tinyradius/util/RadiusServer.java
@@ -57,13 +57,13 @@ public abstract class RadiusServer {
 	 * passed IP address and the received packet data or null if the client 
 	 * is not allowed at this server.
 	 *
-	 * for compatiblity this standard implementation just call the getSharedSecret(InetSocketAddress) method
-	 * and should be overrived when necessary
+	 * for compatibility this standard implementation just call the getSharedSecret(InetSocketAddress) method
+	 * and should be overridden when necessary
 	 * 
 	 * @param client
 	 *            IP address and port number of client
 	 * @param packet
-	 *            packet received from client, the packettype comes as RESERVED, 
+	 *            packet received from client, the packet type comes as RESERVED,
 	 *	      because for some packets the secret is necessary for decoding
 	 * @return shared secret or null
 	 */
@@ -73,17 +73,17 @@ public abstract class RadiusServer {
 
 	/**
 	 * Returns the password of the passed user. Either this
-	 * method or accessRequestReceived() should be overriden.
+	 * method or accessRequestReceived() should be overridden.
 	 * 
 	 * @param userName
-	 *            user name
+	 *            username
 	 * @return plain-text password or null if user unknown
 	 */
 	public abstract String getUserPassword(String userName);
 
 	/**
 	 * Constructs an answer for an Access-Request packet. Either this
-	 * method or isUserAuthenticated should be overriden.
+	 * method or isUserAuthenticated should be overridden.
 	 * 
 	 * @param accessRequest
 	 *            Radius request packet
@@ -107,7 +107,7 @@ public abstract class RadiusServer {
 
 	/**
 	 * Constructs an answer for an Accounting-Request packet. This method
-	 * should be overriden if accounting is supported.
+	 * should be overridden if accounting is supported.
 	 * 
 	 * @param accountingRequest
 	 *            Radius request packet
@@ -227,10 +227,11 @@ public abstract class RadiusServer {
 	 * @param socketTimeout
 	 *            socket timeout, >0 ms
 	 * @throws SocketException
+	 *            Socket Exception
 	 */
 	public void setSocketTimeout(int socketTimeout) throws SocketException {
 		if (socketTimeout < 1)
-			throw new IllegalArgumentException("socket tiemout must be positive");
+			throw new IllegalArgumentException("socket timeout must be positive");
 		this.socketTimeout = socketTimeout;
 		if (authSocket != null)
 			authSocket.setSoTimeout(socketTimeout);
@@ -329,9 +330,8 @@ public abstract class RadiusServer {
 	 *            response packet
 	 */
 	protected void copyProxyState(RadiusPacket request, RadiusPacket answer) {
-		List proxyStateAttrs = request.getAttributes(33);
-		for (Iterator i = proxyStateAttrs.iterator(); i.hasNext();) {
-			RadiusAttribute proxyStateAttr = (RadiusAttribute) i.next();
+		List<RadiusAttribute> proxyStateAttrs = request.getAttributes(33);
+		for (RadiusAttribute proxyStateAttr : proxyStateAttrs) {
 			answer.addAttribute(proxyStateAttr);
 		}
 	}
@@ -341,8 +341,8 @@ public abstract class RadiusServer {
 	 * Returns when stop() is called.
 	 * 
 	 * @throws SocketException
-	 * @throws InterruptedException
-	 * 
+	 *            Socket Exception
+	 *
 	 */
 	protected void listenAuth() throws SocketException {
 		listen(getAuthSocket());
@@ -353,7 +353,7 @@ public abstract class RadiusServer {
 	 * Returns when stop() is called.
 	 * 
 	 * @throws SocketException
-	 * @throws InterruptedException
+	 *            Socket Exception
 	 */
 	protected void listenAcct() throws SocketException {
 		listen(getAcctSocket());
@@ -392,12 +392,12 @@ public abstract class RadiusServer {
 				}
 				else {
 					executor.submit(new Runnable() {
-						
+
 						@Override
 						public void run() {
 							processRequest(s, packetIn);
 						}
-						
+
 					});
 				}
 			}
@@ -472,9 +472,12 @@ public abstract class RadiusServer {
 	 * @param request
 	 *            the packet
 	 * @param sharedSecret
+	 *            shared secret
 	 * @return response packet or null for no response
 	 * @throws RadiusException
+	 *            Radius Exception
 	 * @throws IOException
+	 *            IO Exception
 	 */
 	protected RadiusPacket handlePacket(InetSocketAddress localAddress, InetSocketAddress remoteAddress, RadiusPacket request, String sharedSecret)
 	        throws RadiusException, IOException {
@@ -496,9 +499,8 @@ public abstract class RadiusServer {
 				else
 					logger.error("unknown Radius packet type: " + request.getPacketType());
 			}
-			else {
-				// ignore packet on unknown port
-			}
+			// ignore packet on unknown port
+
 		}
 		else
 			logger.info("ignore duplicate packet");
@@ -511,6 +513,7 @@ public abstract class RadiusServer {
 	 * 
 	 * @return socket
 	 * @throws SocketException
+	 *            Socket Exception
 	 */
 	protected DatagramSocket getAuthSocket() throws SocketException {
 		if (authSocket == null) {
@@ -528,6 +531,7 @@ public abstract class RadiusServer {
 	 * 
 	 * @return socket
 	 * @throws SocketException
+	 *            Socket Exception
 	 */
 	protected DatagramSocket getAcctSocket() throws SocketException {
 		if (acctSocket == null) {
@@ -541,7 +545,7 @@ public abstract class RadiusServer {
 	}
 
 	/**
-	 * Creates a Radius response datagram packet from a RadiusPacket to be send.
+	 * Creates a Radius response datagram packet from a RadiusPacket to be sent.
 	 * 
 	 * @param packet
 	 *            RadiusPacket
@@ -555,6 +559,7 @@ public abstract class RadiusServer {
 	 *            request packet
 	 * @return new datagram packet
 	 * @throws IOException
+	 *            IO Exception
 	 */
 	protected DatagramPacket makeDatagramPacket(RadiusPacket packet, String secret, InetAddress address, int port, RadiusPacket request)
 	        throws IOException {
@@ -562,8 +567,7 @@ public abstract class RadiusServer {
 		packet.encodeResponsePacket(bos, secret, request);
 		byte[] data = bos.toByteArray();
 
-		DatagramPacket datagram = new DatagramPacket(data, data.length, address, port);
-		return datagram;
+		return new DatagramPacket(data, data.length, address, port);
 	}
 
 	/**
@@ -637,6 +641,6 @@ public abstract class RadiusServer {
 	private long lastClean;
 	private long duplicateInterval = 30000; // 30 s
 	protected transient boolean closing = false;
-	private static Log logger = LogFactory.getLog(RadiusServer.class);
+	private static final Log logger = LogFactory.getLog(RadiusServer.class);
 
 }

--- a/src/main/java/org/tinyradius/util/RadiusUtil.java
+++ b/src/main/java/org/tinyradius/util/RadiusUtil.java
@@ -6,7 +6,7 @@
  */
 package org.tinyradius.util;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This class contains miscellaneous static utility functions.
@@ -20,11 +20,7 @@ public class RadiusUtil {
 	 * @return UTF-8 byte array
 	 */
 	public static byte[] getUtf8Bytes(String str) {
-		try {
-			return str.getBytes("UTF-8");
-		} catch (UnsupportedEncodingException uee) {
-			return str.getBytes();
-		}
+		return str.getBytes(StandardCharsets.UTF_8);
 	}
 	
 	/**
@@ -34,11 +30,7 @@ public class RadiusUtil {
 	 * @return Java string
 	 */
 	public static String getStringFromUtf8(byte[] utf8) {
-		try {
-			return new String(utf8, "UTF-8");
-		} catch (UnsupportedEncodingException uee) {
-			return new String(utf8);
-		}
+		return new String(utf8, StandardCharsets.UTF_8);
 	}
 	
 	/**

--- a/src/main/java/org/tinyradius/util/RadiusUtil.java
+++ b/src/main/java/org/tinyradius/util/RadiusUtil.java
@@ -40,10 +40,10 @@ public class RadiusUtil {
 	 * @return hex string
 	 */
 	public static String getHexString(byte[] data) {
-		StringBuffer hex = new StringBuffer("0x");
+		StringBuilder hex = new StringBuilder("0x");
 		if (data != null)
-			for (int i = 0; i < data.length; i++) {
-				String digit = Integer.toString(data[i] & 0x0ff, 16);
+			for (byte datum : data) {
+				String digit = Integer.toString(datum & 0x0ff, 16);
 				if (digit.length() < 2)
 					hex.append('0');
 				hex.append(digit);

--- a/src/main/resources/org/tinyradius/dictionary/default_dictionary
+++ b/src/main/resources/org/tinyradius/dictionary/default_dictionary
@@ -81,7 +81,7 @@ ATTRIBUTE	Login-IPv6-Host		98	octets
 ATTRIBUTE	Framed-IPv6-Route	99	string
 ATTRIBUTE	Framed-IPv6-Pool	100	string
 ATTRIBUTE	Error-Cause		101	integer
-ATTRIBUTE	Delegated-Ipv6-Prefix	123	ipv6addr
+ATTRIBUTE	Delegated-IPv6-Prefix	123	ipv6prefix
 ATTRIBUTE	Framed-IPv6-Address	168	ipv6addr
 ATTRIBUTE	DNS-Server-IPv6-Address	169	ipv6addr
 ATTRIBUTE	Route-IPv6-Information	170	octets

--- a/src/test/java/org/tinyradius/attribute/IntegerAttributeTest.java
+++ b/src/test/java/org/tinyradius/attribute/IntegerAttributeTest.java
@@ -9,7 +9,7 @@ public class IntegerAttributeTest {
 	@Test
 	public void test() {
 		final IntegerAttribute intAttr = new IntegerAttribute(27, 0);
-		final long bigValue = 0xffffffffl; // big value with highest bit set
+		final long bigValue = 0xffffffffL; // big value with highest bit set
 		System.err.println((int)bigValue);
 		System.err.println(bigValue);
 		final String bigValueSt = Long.toString(bigValue);

--- a/src/test/java/org/tinyradius/attribute/IntegerAttributeTest.java
+++ b/src/test/java/org/tinyradius/attribute/IntegerAttributeTest.java
@@ -1,20 +1,21 @@
 package org.tinyradius.attribute;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
 
 public class IntegerAttributeTest {
 
 	@Test
 	public void test() {
 		final IntegerAttribute intAttr = new IntegerAttribute(27, 0);
-		final long bigValue = 0xffffffffL; // big value with highest bit set
-		System.err.println((int)bigValue);
-		System.err.println(bigValue);
+		final long bigValue = 0xffffffffL; // big value with the highest bit set
 		final String bigValueSt = Long.toString(bigValue);
 		intAttr.setAttributeValue(bigValueSt);
-		assertEquals(bigValueSt, intAttr.getAttributeValue());
+		//System.err.println(intAttr.getAttributeTypeObject().getName());
+		Assertions.assertEquals(IntegerAttribute.class, intAttr.getAttributeTypeObject().getAttributeClass());
+		Assertions.assertEquals("Session-Timeout", intAttr.getAttributeTypeObject().getName());
+		Assertions.assertEquals(bigValueSt, intAttr.getAttributeValue());
 	}
 
 }

--- a/src/test/java/org/tinyradius/attribute/IpAttributeTest.java
+++ b/src/test/java/org/tinyradius/attribute/IpAttributeTest.java
@@ -1,0 +1,18 @@
+package org.tinyradius.attribute;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class IpAttributeTest {
+
+	@Test
+	public void test() {
+		final IpAttribute ipAttr = new IpAttribute(8,"192.168.1.2");
+		//System.err.println(ipAttr.getAttributeTypeObject().getName());
+
+		Assertions.assertEquals(IpAttribute.class, ipAttr.getAttributeTypeObject().getAttributeClass());
+		Assertions.assertEquals("Framed-IP-Address", ipAttr.getAttributeTypeObject().getName());
+		Assertions.assertEquals(3232235778L, ipAttr.getIpAsLong());
+	}
+
+}

--- a/src/test/java/org/tinyradius/attribute/Ipv6AttributeTest.java
+++ b/src/test/java/org/tinyradius/attribute/Ipv6AttributeTest.java
@@ -1,0 +1,17 @@
+package org.tinyradius.attribute;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class Ipv6AttributeTest {
+
+	@Test
+	public void test() {
+		final String testIpv6Addr = "2001:db8:85a3:0:0:0:0:1234";
+		final Ipv6Attribute ipv6Attr = new Ipv6Attribute(168, testIpv6Addr);
+		Assertions.assertEquals(Ipv6Attribute.class, ipv6Attr.getAttributeTypeObject().getAttributeClass());
+		Assertions.assertEquals("Framed-IPv6-Address", ipv6Attr.getAttributeTypeObject().getName());
+		Assertions.assertEquals(testIpv6Addr, ipv6Attr.getAttributeValue());
+	}
+
+}

--- a/src/test/java/org/tinyradius/attribute/Ipv6PrefixAttributeTest.java
+++ b/src/test/java/org/tinyradius/attribute/Ipv6PrefixAttributeTest.java
@@ -1,0 +1,18 @@
+package org.tinyradius.attribute;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class Ipv6PrefixAttributeTest {
+
+	@Test
+	public void test() {
+		final String testIpv6Prefix = "2001:db8:85a3::/56";
+		final Ipv6PrefixAttribute ipv6PrefixAttr = new Ipv6PrefixAttribute(123, testIpv6Prefix);
+		//System.err.println(ipv6Prefix);
+		Assertions.assertEquals(Ipv6PrefixAttribute.class, ipv6PrefixAttr.getAttributeTypeObject().getAttributeClass());
+		Assertions.assertEquals("Delegated-IPv6-Prefix", ipv6PrefixAttr.getAttributeTypeObject().getName());
+		Assertions.assertEquals(testIpv6Prefix, ipv6PrefixAttr.getAttributeValue());
+	}
+
+}

--- a/src/test/java/org/tinyradius/attribute/StringAttributeTest.java
+++ b/src/test/java/org/tinyradius/attribute/StringAttributeTest.java
@@ -1,0 +1,18 @@
+package org.tinyradius.attribute;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StringAttributeTest {
+
+	@Test
+	public void test() {
+		final String username = "jdoe@example.com";
+		final StringAttribute strAttr = new StringAttribute(1, username);
+		//System.err.println(strAttr);
+		Assertions.assertEquals(StringAttribute.class, strAttr.getAttributeTypeObject().getAttributeClass());
+		Assertions.assertEquals("User-Name", strAttr.getAttributeTypeObject().getName());
+		Assertions.assertEquals(username, strAttr.getAttributeValue());
+	}
+
+}

--- a/src/test/java/org/tinyradius/attribute/VendorSpecificAttributeTest.java
+++ b/src/test/java/org/tinyradius/attribute/VendorSpecificAttributeTest.java
@@ -1,0 +1,20 @@
+package org.tinyradius.attribute;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class VendorSpecificAttributeTest {
+
+	@Test
+	public void test() {
+		final String vsaName = "WISPr-Location-Name";
+		final String vsaValue = "somewhere";
+		VendorSpecificAttribute vsa = new VendorSpecificAttribute(14122);
+		vsa.addSubAttribute(vsaName, vsaValue);
+		//System.err.println(vsa);
+		Assertions.assertEquals(VendorSpecificAttribute.class, vsa.getAttributeTypeObject().getAttributeClass());
+		Assertions.assertEquals("Vendor-Specific", vsa.getAttributeTypeObject().getName());
+		Assertions.assertEquals(vsaValue, vsa.getSubAttributeValue(vsaName));
+	}
+
+}


### PR DESCRIPTION
Was having a fair number of warnings/issues compiling for Java 8/11 so thought I'd update some of the code for use with current supported JVMs.  Mainly updates to migrate toward Java 8/11 code style.  
- Set type and checks for raw maps, lists, sets, classes, etc.
- Migrate to Junit 5 
- Some additional unit tests for RadiusAttribute subclasses (additional unit tests still needed)
- Minor code changes/cleanup for Java 8+

I only use library with RADIUS client so server code not tested.  Feel free to merge changes or toss as see fit.  Happy to make additional changes if needed.