### PR TITLE
Quick Patch for CVE-2024-3596 to include Message-Authenticator in all…

### DIFF
--- a/src/main/java/org/tinyradius/packet/RadiusPacket.java
+++ b/src/main/java/org/tinyradius/packet/RadiusPacket.java
@@ -865,7 +865,7 @@ public class RadiusPacket {
 				}
 			}
 			if (!exists) {
-				this.attributes.add(new RadiusAttribute(MESSAGE_AUTHENTICATOR, new byte[16]));
+				this.attributes.addFirst(new RadiusAttribute(MESSAGE_AUTHENTICATOR, new byte[16]));
 			}
 		}
 


### PR DESCRIPTION
Patch for CVE-2024-3596 to send all responses with Message-Authenticator Attribute. This patch only handles adding attribute in responses. For full fix we need to also validate Message-Authenticator Attribute when decoding packages.